### PR TITLE
Issue with command `geneos aes set` and option `-C`

### DIFF
--- a/tools/geneos/cmd/aesSet.go
+++ b/tools/geneos/cmd/aesSet.go
@@ -25,6 +25,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"strings"
 
@@ -46,8 +47,9 @@ func init() {
 	aesCmd.AddCommand(aesSetCmd)
 
 	defKeyFile := geneos.UserConfigFilePaths("keyfile.aes")[0]
+
 	aesSetCmd.Flags().StringVarP(&aesSetCmdKeyfile, "keyfile", "k", defKeyFile, "Keyfile to use")
-	aesSetCmd.Flags().StringVarP(&aesSetCmdCRC, "crc", "C", "", "CRC of keyfile to use.")
+	aesSetCmd.Flags().StringVarP(&aesSetCmdCRC, "crc", "C", "", "CRC of existing component shared keyfile to use")
 	aesSetCmd.Flags().BoolVarP(&aesSetCmdNoRoll, "noroll", "N", false, "Do not roll any existing keyfile to previous keyfile setting")
 }
 
@@ -55,13 +57,16 @@ var aesSetCmd = &cobra.Command{
 	Use:   "set [flags] [TYPE] [NAME...]",
 	Short: "Set keyfile for instances",
 	Long: strings.ReplaceAll(`
-Set keyfile for matching instances. Either a path or URL to a
-keyfile or the CRC of an existing keyfile in the component's shared
-directory must be given. If a path or URL is given then the keyfile
-is saved to the component shared directories and the configuration
-set to reference that path. Unless the |-N| flag is given any
-existing keyfile path is copied to a 'prevkeyfile' setting to support
-key file updating in Geneos GA6.x.
+Set keyfile for matching instances.
+
+Either a path or URL to a keyfile, the CRC of an existing keyfile in
+a local component's shared directory can be given or, if it exists, the
+user's default keyfile is used. Unless the keyfile is referenced by
+the CRC it is saved to the component shared directories and the
+configuration set to reference that path.
+
+Unless the |-N| flag is given any existing keyfile path is copied to
+a 'prevkeyfile' setting to support key file updating in Geneos GA6.x.
 
 If the |-C| flag is used and it identifies an existing keyfile in the
 component keyfile directory then that is used for matching instances.
@@ -71,21 +76,50 @@ a prefix of |~/| to represent the home directory), a URL or a dash
 |-| for STDIN.
 
 Currently only Gateways and Netprobes (and SANs) are supported.
+
+Only local keyfiles, unless given as a URL, can be copied to remote
+hosts, not visa versa.
 `, "|", "`"),
 	SilenceUsage: true,
 	Annotations: map[string]string{
 		"wildcard": "true",
 	},
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		ct, args, _ := cmdArgsParams(cmd)
-		var params []string
+	RunE: func(cmd *cobra.Command, _ []string) (err error) {
+		ct, args := cmdArgs(cmd)
 
-		f, _, err := geneos.OpenSource(aesSetCmdKeyfile)
-		if err != nil {
-			return err
+		var crclist []string
+		var f io.ReadCloser
+		var a config.AESValues
+
+		if aesSetCmdCRC == "" {
+			f, _, err = geneos.OpenSource(aesSetCmdKeyfile)
+			if err != nil {
+				return err
+			}
+		} else {
+			// search for existing CRC in all shread dirs
+			var path string
+			for _, ct := range ct.Range(&gateway.Gateway, &netprobe.Netprobe, &san.San) {
+				path = host.LOCAL.Filepath(ct, ct.String()+"_shared", "keyfiles", aesSetCmdCRC+".aes")
+				log.Debug().Msgf("looking for keyfile %s", path)
+				if _, err := host.LOCAL.Stat(path); err == nil {
+					break
+				}
+				path = ""
+			}
+
+			if path == "" {
+				return fmt.Errorf("keyfile with CRC %q not found locally", aesSetCmdCRC)
+			}
+
+			f, _, err = geneos.OpenSource(path)
+			if err != nil {
+				return err
+			}
 		}
 		defer f.Close()
-		a, err := config.ReadAESValues(f)
+
+		a, err = config.ReadAESValues(f)
 		if err != nil {
 			return err
 		}
@@ -93,43 +127,31 @@ Currently only Gateways and Netprobes (and SANs) are supported.
 		if err != nil {
 			return err
 		}
-		crcstr := fmt.Sprintf("%08X", crc)
-		params = []string{crcstr}
-
-		if aesSetCmdCRC != "" {
-			params = []string{aesSetCmdCRC}
-		}
+		crclist = []string{fmt.Sprintf("%08X", crc)}
 
 		// at this point we have an AESValue struct and a CRC to use as a test
 		// create 'keyfiles' directory as required
 		for _, ct := range ct.Range(&gateway.Gateway, &netprobe.Netprobe, &san.San) {
 			for _, h := range host.AllHosts() {
-				if aesSetCmdCRC != "" {
-					path := h.Filepath(ct, ct.String()+"_shared", "keyfiles", aesSetCmdCRC+".aes")
-					if _, err := h.Stat(path); err != nil && errors.Is(err, fs.ErrNotExist) {
-						aesImportSave(ct, h, &a)
-					}
-				} else {
+				// only import if it is not found
+				path := h.Filepath(ct, ct.String()+"_shared", "keyfiles", crclist[0]+".aes")
+				if _, err := h.Stat(path); err != nil && errors.Is(err, fs.ErrNotExist) {
 					aesImportSave(ct, h, &a)
+				} else if err == nil {
+					log.Debug().Msgf("not importing existing %q CRC named keyfile on %s", crclist[0], h)
 				}
-
 			}
 		}
 
-		if len(params) == 0 {
-			fmt.Println("nothing to do")
-			return nil
-		}
-
 		// params[0] is the CRC
-		instance.ForAll(ct, aesSetAESInstance, args, params)
+		for _, ct := range ct.Range(&gateway.Gateway, &netprobe.Netprobe, &san.San) {
+			instance.ForAll(ct, aesSetAESInstance, args, crclist)
+		}
 		return nil
 	},
 }
 
 func aesSetAESInstance(c geneos.Instance, params []string) (err error) {
-	var rolled bool
-
 	path := c.Host().Filepath(c.Type(), c.Type().String()+"_shared", "keyfiles", params[0]+".aes")
 
 	// roll old file
@@ -137,23 +159,19 @@ func aesSetAESInstance(c geneos.Instance, params []string) (err error) {
 		p := c.Config().GetString("keyfile")
 		if p != "" {
 			if p == path {
-				fmt.Printf("%s: new and existing keyfile have same CRC. Not updating.", c)
+				fmt.Printf("%s: new and existing keyfile have same CRC. Not updating\n", c)
 			} else {
 				c.Config().Set("keyfile", path)
-				fmt.Printf("%s keyfile %s set", c, params[0])
 				c.Config().Set("prevkeyfile", p)
-				rolled = true
+				fmt.Printf("%s keyfile %s set, existing keyfile moved to prevkeyfile\n", c, params[0])
 			}
+		} else {
+			c.Config().Set("keyfile", path)
+			fmt.Printf("%s keyfile %s set\n", c, params[0])
 		}
 	} else {
 		c.Config().Set("keyfile", path)
-		fmt.Printf("%s keyfile %s set", c, params[0])
-	}
-
-	if rolled {
-		fmt.Printf(", existing keyfile moved to prevkeyfile\n")
-	} else {
-		fmt.Println(c)
+		fmt.Printf("%s keyfile %s set\n", c, params[0])
 	}
 
 	if err = instance.WriteConfig(c); err != nil {


### PR DESCRIPTION
Fixes #45

* rebuild logic, only locally available keyfiles are imported by CRC