### PR TITLE
Unexpected behaviour of `geneos home gateway`

### DIFF
--- a/tools/geneos/cmd/home.go
+++ b/tools/geneos/cmd/home.go
@@ -65,6 +65,11 @@ cat $(geneos home gateway example2)/gateway.txt
 			return nil
 		}
 
+		if ct != nil && len(args) == 0 {
+			fmt.Println(host.LOCAL.Filepath(ct))
+			return nil
+		}
+
 		var i []geneos.Instance
 		if len(args) == 0 {
 			i = instance.GetAll(host.LOCAL, ct)


### PR DESCRIPTION
Fixes #56

Now returns base directory for component if no instance name is given