### PR TITLE
startup -l or log with --errors doesn't show normal logs

### DIFF
--- a/tools/geneos/cmd/_docs/logs.md
+++ b/tools/geneos/cmd/_docs/logs.md
@@ -13,7 +13,8 @@ for all matching instances including remote ones. `--cat`/`-c` and
 
 The `--stderr`/`-E` option controls whether the separate `STDERR` log
 (if there is one) for each matching instance is also shown along with
-the main log. There is no way currently to only view the `STDERR` logs.
+the main log. If used with the `--nostandard`/`-N` option to suppress
+normal log files then only error output is shown.
 
 The `--match`/`-g` and `--ignore`/`-v` options will filter lines the
 output based on a case sensitive search over the whole line. As can be

--- a/tools/geneos/cmd/restart.go
+++ b/tools/geneos/cmd/restart.go
@@ -73,10 +73,9 @@ func commandRestart(ct *geneos.Component, args []string, params []string) (err e
 	}
 
 	if restartCmdLogs {
-		// watch STDERR on start-up
-		logCmdStderr = true
+		// also watch STDERR on start-up
 		// never returns
-		return followLogs(ct, args, params)
+		return followLogs(ct, args, params, true)
 	}
 	return
 }

--- a/tools/geneos/cmd/start.go
+++ b/tools/geneos/cmd/start.go
@@ -67,10 +67,9 @@ func Start(ct *geneos.Component, watchlogs bool, args []string, params []string)
 	}
 
 	if watchlogs {
-		// watch STDERR on start-up
-		logCmdStderr = true
+		// also watch STDERR on start-up
 		// never returns
-		return followLogs(ct, args, params)
+		return followLogs(ct, args, params, true)
 	}
 
 	return


### PR DESCRIPTION
Fixes #86

* also abstract stderr flag for start/restart
* add a --nostandard option