### PR TITLE
enhance `geneos tls` for more general use

### DIFF
--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -1,0 +1,281 @@
+/*
+Copyright © 2023 ITRS Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/awnumar/memguard"
+	"github.com/itrs-group/cordial/pkg/host"
+	"github.com/rs/zerolog/log"
+)
+
+// ReadKey reads a keyfile and saves the PEM encoded key in an
+// enclave (without type or headers)
+func ReadKey(h host.Host, path string) (key *memguard.Enclave, err error) {
+	keyPEM, err := h.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	for {
+		p, rest := pem.Decode(keyPEM)
+		if p == nil {
+			return nil, fmt.Errorf("cannot locate RSA private key in %s", path)
+		}
+		if p.Type == "RSA PRIVATE KEY" {
+			key = memguard.NewEnclave(p.Bytes)
+			return
+		}
+		keyPEM = rest
+	}
+}
+
+// WriteKey writes a private key as PEM to path on host h. sets file
+// permissions to 0600 (before umask)
+func WriteKey(h host.Host, path string, key *memguard.Enclave) (err error) {
+	l, _ := key.Open()
+	defer l.Destroy()
+	p := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: l.Bytes(),
+	})
+	return h.WriteFile(path, p, 0600)
+}
+
+// ReadCert reads a PEM encoded cert from path on host h, return the
+// first found as a parsed certificate
+func ReadCert(h host.Host, path string) (cert *x509.Certificate, err error) {
+	certPEM, err := h.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	for {
+		p, rest := pem.Decode(certPEM)
+		if p == nil {
+			return nil, fmt.Errorf("cannot locate certificate in %s", path)
+		}
+		if p.Type == "CERTIFICATE" {
+			return x509.ParseCertificate(p.Bytes)
+		}
+		certPEM = rest
+	}
+}
+
+// WriteCert writes cert as PEM to path on host h
+func WriteCert(h host.Host, path string, cert *x509.Certificate) (err error) {
+	log.Debug().Msgf("write cert to %s", path)
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+
+	return h.WriteFile(path, certPEM, 0644)
+}
+
+// WriteCerts concatenate certs and writes to path on host h
+func WriteCerts(h host.Host, path string, certs ...*x509.Certificate) (err error) {
+	log.Debug().Msgf("write certs to %s", path)
+	var certsPEM []byte
+	for _, cert := range certs {
+		if cert == nil {
+			continue
+		}
+		p := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		})
+		certsPEM = append(certsPEM, p...)
+	}
+	return h.WriteFile(path, certsPEM, 0644)
+}
+
+// CreateCertKey is a wrapper to create a new certificate given the
+// signing cert and private key and an optional private key to (re)use
+// for the created certificate itself. returns a certificate and private
+// key. Keys are in PEM format so need parsing after unsealing.
+func CreateCertKey(template, parent *x509.Certificate, parentKeyPEM, existingKeyPEM *memguard.Enclave) (cert *x509.Certificate, keyPEM *memguard.Enclave, err error) {
+	var certBytes []byte
+	var certKey *rsa.PrivateKey
+
+	if template != parent && parentKeyPEM == nil {
+		err = errors.New("parent key empty but not self-signing")
+		return
+	}
+
+	keyPEM = existingKeyPEM
+	if keyPEM == nil {
+		keyPEM = NewPrivateKey()
+	}
+
+	l, _ := keyPEM.Open()
+	if certKey, err = x509.ParsePKCS1PrivateKey(l.Bytes()); err != nil {
+		keyPEM = nil
+		return
+	}
+
+	signingKey := certKey
+	certPubKey := &certKey.PublicKey
+
+	if parentKeyPEM != nil {
+		pk, _ := parentKeyPEM.Open()
+		if signingKey, err = x509.ParsePKCS1PrivateKey(pk.Bytes()); err != nil {
+			keyPEM = nil
+			return
+		}
+		pk.Destroy()
+	}
+
+	if certBytes, err = x509.CreateCertificate(rand.Reader, template, parent, certPubKey, signingKey); err != nil {
+		keyPEM = nil
+		l.Destroy()
+		return
+	}
+
+	if cert, err = x509.ParseCertificate(certBytes); err != nil {
+		keyPEM = nil
+		l.Destroy()
+		return
+	}
+
+	keyPEM = l.Seal()
+	return
+}
+
+// NewPrivateKey returns a PKCS1 encoded RSA Private Key as an enclave.
+// It is not PEM encoded.
+func NewPrivateKey() *memguard.Enclave {
+	certKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
+
+	return memguard.NewEnclave(x509.MarshalPKCS1PrivateKey(certKey))
+}
+
+// CreateRootCert creates a new root certificate and private key and
+// saves it with dir and file basefilepath with .pem and .key extensions. If
+// overwrite is true then any existing certificate and key is
+// overwritten.
+func CreateRootCert(h host.Host, basefilepath string, overwrite bool) (err error) {
+	// create rootCA.pem / rootCA.key
+	var cert *x509.Certificate
+
+	if !overwrite {
+		if _, err = ReadCert(h, basefilepath+".pem"); err == nil {
+			return host.ErrExists
+		}
+	}
+	serial, err := rand.Prime(rand.Reader, 64)
+	if err != nil {
+		return
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "geneos root CA",
+		},
+		NotBefore:             time.Now().Add(-60 * time.Second),
+		NotAfter:              time.Now().AddDate(10, 0, 0).Truncate(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		MaxPathLen:            2,
+	}
+
+	cert, key, err := CreateCertKey(template, template, nil, nil)
+	if err != nil {
+		return
+	}
+
+	if err = WriteCert(h, basefilepath+".pem", cert); err != nil {
+		return
+	}
+	if err = WriteKey(h, basefilepath+".key", key); err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateSigningCert creates a new signing certificate and private key
+// with the path and file bane name basefilepath. You must provide a
+// valid root certificate and key in rootbasefilepath. If overwrite is
+// true than any existing cert and key are overwritten.
+func CreateSigningCert(h host.Host, basefilepath string, rootbasefilepath string, overwrite bool) (err error) {
+	var cert *x509.Certificate
+
+	if !overwrite {
+		if _, err = ReadCert(h, basefilepath+".pem"); err == nil {
+			return host.ErrExists
+		}
+	}
+
+	serial, err := rand.Prime(rand.Reader, 64)
+	if err != nil {
+		return
+	}
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "geneos intermediate CA",
+		},
+		NotBefore:             time.Now().Add(-60 * time.Second),
+		NotAfter:              time.Now().AddDate(10, 0, 0).Truncate(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		MaxPathLen:            1,
+	}
+
+	rootCert, err := ReadCert(h, rootbasefilepath+".pem")
+	if err != nil {
+		return
+	}
+	rootKey, err := ReadKey(h, rootbasefilepath+".key")
+	if err != nil {
+		return
+	}
+
+	cert, key, err := CreateCertKey(&template, rootCert, rootKey, nil)
+	if err != nil {
+		return
+	}
+
+	if err = WriteCert(h, basefilepath+".pem", cert); err != nil {
+		return
+	}
+	if err = WriteKey(h, basefilepath+".key", key); err != nil {
+		return
+	}
+
+	return
+}

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -84,6 +84,8 @@ var (
 	ErrInvalidArgs  = errors.New("invalid arguments")
 	ErrNotSupported = errors.New("not supported")
 	ErrNotAvailable = errors.New("not available")
+	ErrExists       = errors.New("exists")
+	ErrNotExists    = errors.New("not exists")
 )
 
 // CopyFile copies a file between two locations. Destination can be a

--- a/tools/geneos/cmd/tlscmd/_docs/new.md
+++ b/tools/geneos/cmd/tlscmd/_docs/new.md
@@ -1,1 +1,10 @@
-Create new certificates for instances.
+By default the `new` command creates new certificates for matching
+instances. It overwrites existing certificates.
+
+Using the `--named`/`-n` option will instead create a new certificate
+and key pair for the CN (Common Name) cn and name the file for the CN
+with spaces replaced by dashes. The Subject Alternative Name for the
+certificate is set from the machine hostname but can be overridden using
+the global `--hostname`/`-H` option. The certificate and key are
+written to a .pem and .key file in the current directory unless you use
+the `--dir`/`-D` option.

--- a/tools/geneos/cmd/tlscmd/import.go
+++ b/tools/geneos/cmd/tlscmd/import.go
@@ -36,6 +36,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/itrs-group/cordial/pkg/config"
 	"github.com/itrs-group/cordial/tools/geneos/cmd"
 	"github.com/itrs-group/cordial/tools/geneos/internal/geneos"
 )
@@ -138,11 +139,11 @@ func tlsImport(sources ...string) (err error) {
 			keys = keys[:i]
 		}
 
-		if err = geneos.LOCAL.WriteCert(filepath.Join(tlsPath, prefix+".pem"), cert); err != nil {
+		if err = config.WriteCert(geneos.LOCAL, filepath.Join(tlsPath, prefix+".pem"), cert); err != nil {
 			return err
 		}
 		fmt.Printf("imported %s certificate to %q\n", title, filepath.Join(tlsPath, prefix+".pem"))
-		if err = geneos.LOCAL.WriteKey(filepath.Join(tlsPath, prefix+".key"), key); err != nil {
+		if err = config.WriteKey(geneos.LOCAL, filepath.Join(tlsPath, prefix+".key"), key); err != nil {
 			return err
 		}
 		fmt.Printf("imported %s RSA private key to %q\n", title, filepath.Join(tlsPath, prefix+".pem"))

--- a/tools/geneos/cmd/tlscmd/init.go
+++ b/tools/geneos/cmd/tlscmd/init.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/itrs-group/cordial/pkg/config"
 	"github.com/itrs-group/cordial/tools/geneos/internal/geneos"
-	"github.com/itrs-group/cordial/tools/geneos/internal/instance"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +76,7 @@ func tlsInit() (err error) {
 		log.Fatal().Err(err).Msg("")
 	}
 
-	if err := instance.CreateRootCA(tlsPath, tlsInitCmdOverwrite); err != nil {
+	if err := config.CreateRootCert(geneos.LOCAL, filepath.Join(tlsPath, geneos.RootCAFile), tlsInitCmdOverwrite); err != nil {
 		if errors.Is(err, geneos.ErrExists) {
 			fmt.Println("root certificate already exists in", tlsPath)
 			return nil
@@ -84,7 +84,7 @@ func tlsInit() (err error) {
 	}
 	fmt.Printf("CA certificate created for %s\n", geneos.RootCAFile)
 
-	if err := instance.CreateSigningCert(tlsPath, tlsInitCmdOverwrite); err != nil {
+	if err := config.CreateSigningCert(geneos.LOCAL, filepath.Join(tlsPath, geneos.SigningCertFile), filepath.Join(tlsPath, geneos.RootCAFile), tlsInitCmdOverwrite); err != nil {
 		if errors.Is(err, geneos.ErrExists) {
 			fmt.Println("signing certificate already exists in", tlsPath)
 			return nil

--- a/tools/geneos/cmd/tlscmd/new.go
+++ b/tools/geneos/cmd/tlscmd/new.go
@@ -23,17 +23,32 @@ THE SOFTWARE.
 package tlscmd
 
 import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/itrs-group/cordial/pkg/config"
 	"github.com/itrs-group/cordial/tools/geneos/cmd"
 	"github.com/itrs-group/cordial/tools/geneos/internal/geneos"
 	"github.com/itrs-group/cordial/tools/geneos/internal/instance"
 )
 
+var tlsNewCmdNamed, tlsNewCmdDir string
+
 func init() {
 	tlsCmd.AddCommand(tlsNewCmd)
+
+	tlsNewCmd.Flags().StringVarP(&tlsNewCmdNamed, "named", "n", "", "Create a named certificate and key in current directory. `CN` is the name used.")
+	tlsNewCmd.Flags().StringVarP(&tlsNewCmdDir, "dir", "D", ".", "Write to directory `DIR` for named certificate and key.")
 }
 
 //go:embed _docs/new.md
@@ -49,6 +64,13 @@ var tlsNewCmd = &cobra.Command{
 		"needshomedir": "true",
 	},
 	RunE: func(command *cobra.Command, _ []string) error {
+		if tlsNewCmdNamed != "" {
+			hostname, _ := os.Hostname()
+			if cmd.Hostname != "all" {
+				hostname = cmd.Hostname
+			}
+			return CreateCert(tlsNewCmdDir, tlsNewCmdNamed, hostname)
+		}
 		ct, args, params := cmd.CmdArgsParams(command)
 		return instance.ForAll(ct, cmd.Hostname, newInstanceCert, args, params)
 	},
@@ -56,4 +78,63 @@ var tlsNewCmd = &cobra.Command{
 
 func newInstanceCert(c geneos.Instance, _ []string) (err error) {
 	return instance.CreateCert(c)
+}
+
+// CreateCert creates a new certificate
+//
+// this also creates a new private key
+//
+// skip if certificate exists and is valid
+func CreateCert(dir string, cn string, hostname string) (err error) {
+	tlsDir := filepath.Join(geneos.Root(), "tls")
+
+	serial, err := rand.Prime(rand.Reader, 64)
+	if err != nil {
+		return
+	}
+	expires := time.Now().AddDate(1, 0, 0).Truncate(24 * time.Hour)
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		NotBefore:      time.Now().Add(-60 * time.Second),
+		NotAfter:       expires,
+		KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		MaxPathLenZero: true,
+		DNSNames:       []string{hostname},
+		// IPAddresses:    []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	// rootCert, _ = instance.ReadRootCert(filepath.Join(geneos.Root(), "tls"))
+	intrCert, err := config.ReadCert(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".cert"))
+	if err != nil {
+		log.Error().Err(err).Msg("")
+		return
+	}
+	intrKey, err := config.ReadKey(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".key"))
+	if err != nil {
+		log.Error().Err(err).Msg("")
+		return
+	}
+
+	cert, key, err := config.CreateCertKey(&template, intrCert, intrKey, nil)
+	if err != nil {
+		return
+	}
+
+	c := filepath.Join(dir, strings.ReplaceAll(cn, " ", "-"))
+
+	if err = config.WriteCert(geneos.LOCAL, c+".pem", cert); err != nil {
+		return
+	}
+
+	if err = config.WriteKey(geneos.LOCAL, c+".key", key); err != nil {
+		return
+	}
+
+	fmt.Printf("certificate created for %s (expires %s)\n", c, expires.UTC())
+
+	return
 }

--- a/tools/geneos/cmd/tlscmd/renew.go
+++ b/tools/geneos/cmd/tlscmd/renew.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/itrs-group/cordial/pkg/config"
 	"github.com/itrs-group/cordial/tools/geneos/cmd"
 	"github.com/itrs-group/cordial/tools/geneos/internal/geneos"
 	"github.com/itrs-group/cordial/tools/geneos/internal/instance"
@@ -89,18 +90,18 @@ func renewInstanceCert(c geneos.Instance, _ []string) (err error) {
 		// IPAddresses:    []net.IP{net.ParseIP("127.0.0.1")},
 	}
 
-	intrCert, err := geneos.LOCAL.ReadCert(filepath.Join(tlsDir, geneos.SigningCertFile+".pem"))
+	intrCert, err := config.ReadCert(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".pem"))
 	if err != nil {
 		return
 	}
-	intrKey, err := geneos.LOCAL.ReadKey(filepath.Join(tlsDir, geneos.SigningCertFile+".key"))
+	intrKey, err := config.ReadKey(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".key"))
 	if err != nil {
 		return
 	}
 
 	// read existing key or create a new one
 	existingKey, _ := instance.ReadKey(c)
-	cert, key, err := instance.CreateCertKey(&template, intrCert, intrKey, existingKey)
+	cert, key, err := config.CreateCertKey(&template, intrCert, intrKey, existingKey)
 	if err != nil {
 		return
 	}

--- a/tools/geneos/cmd/tlscmd/sync.go
+++ b/tools/geneos/cmd/tlscmd/sync.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/itrs-group/cordial/pkg/config"
 	"github.com/itrs-group/cordial/tools/geneos/internal/geneos"
 	"github.com/itrs-group/cordial/tools/geneos/internal/instance"
 	"github.com/spf13/cobra"
@@ -78,7 +79,7 @@ func tlsSync() (err error) {
 		if err = r.MkdirAll(tlsPath, 0775); err != nil {
 			return
 		}
-		if err = r.WriteCerts(filepath.Join(tlsPath, "chain.pem"), rootCert, geneosCert); err != nil {
+		if err = config.WriteCerts(r, filepath.Join(tlsPath, "chain.pem"), rootCert, geneosCert); err != nil {
 			return
 		}
 

--- a/tools/geneos/docs/geneos_tls_new.md
+++ b/tools/geneos/docs/geneos_tls_new.md
@@ -6,7 +6,23 @@ Create new certificates
 geneos tls new [TYPE] [NAME...] [flags]
 ```
 
-Create new certificates for instances.
+By default the `new` command creates new certificates for matching
+instances. It overwrites existing certificates.
+
+Using the `--named`/`-n` option will instead create a new certificate
+and key pair for the CN (Common Name) cn and name the file for the CN
+with spaces replaced by dashes. The Subject Alternative Name for the
+certificate is set from the machine hostname but can be overridden using
+the global `--hostname`/`-H` option. The certificate and key are
+written to a .pem and .key file in the current directory unless you use
+the `--dir`/`-D` option.
+
+### Options
+
+```text
+  -D, --dir DIR    Write to directory DIR for named certificate and key. (default ".")
+  -n, --named CN   Create a named certificate and key in current directory. CN is the name used.
+```
 
 ## SEE ALSO
 

--- a/tools/geneos/internal/geneos/utils.go
+++ b/tools/geneos/internal/geneos/utils.go
@@ -23,20 +23,16 @@ THE SOFTWARE.
 package geneos
 
 import (
-	"crypto/x509"
-	"encoding/pem"
-	"fmt"
 	"path/filepath"
 	"strings"
 
-	"github.com/awnumar/memguard"
 	"github.com/itrs-group/cordial/pkg/host"
 	"github.com/rs/zerolog/log"
 )
 
-// given a path return a cleaned version. If the cleaning results in and
-// absolute path or one that tries to ascend the tree then return an
-// error
+// CleanRelativePath given a path returns a cleaned version. If the
+// cleaning results in and absolute path or one that tries to ascend the
+// tree then return an error
 func CleanRelativePath(path string) (clean string, err error) {
 	clean = filepath.Clean(path)
 	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "../") {
@@ -45,83 +41,4 @@ func CleanRelativePath(path string) (clean string, err error) {
 	}
 
 	return
-}
-
-// ReadKey reads a keyfile and saves the PEM encoded key in an
-// enclave (without type or headers)
-func (r *Host) ReadKey(path string) (key *memguard.Enclave, err error) {
-	keyPEM, err := r.ReadFile(path)
-	if err != nil {
-		return
-	}
-
-	for {
-		p, rest := pem.Decode(keyPEM)
-		if p == nil {
-			return nil, fmt.Errorf("cannot locate RSA private key in %s", path)
-		}
-		if p.Type == "RSA PRIVATE KEY" {
-			key = memguard.NewEnclave(p.Bytes)
-			return
-		}
-		keyPEM = rest
-	}
-}
-
-// write a private key as PEM to path. sets file permissions to 0600 (before umask)
-func (r *Host) WriteKey(path string, key *memguard.Enclave) (err error) {
-	l, _ := key.Open()
-	defer l.Destroy()
-	p := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: l.Bytes(),
-	})
-	return r.WriteFile(path, p, 0600)
-}
-
-// read a PEM encoded cert from path, return the first found as a parsed certificate
-func (r *Host) ReadCert(path string) (cert *x509.Certificate, err error) {
-	certPEM, err := r.ReadFile(path)
-	if err != nil {
-		return
-	}
-
-	for {
-		p, rest := pem.Decode(certPEM)
-		if p == nil {
-			return nil, fmt.Errorf("cannot locate certificate in %s", path)
-		}
-		if p.Type == "CERTIFICATE" {
-			return x509.ParseCertificate(p.Bytes)
-		}
-		certPEM = rest
-	}
-}
-
-// write cert as PEM to path
-func (r *Host) WriteCert(path string, cert *x509.Certificate) (err error) {
-	log.Debug().Msgf("write cert to %s", path)
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert.Raw,
-	})
-
-	return r.WriteFile(path, certPEM, 0644)
-}
-
-// concatenate certs and write to path
-func (r *Host) WriteCerts(path string, certs ...*x509.Certificate) (err error) {
-	log.Debug().Msgf("write certs to %s", path)
-	var certsPEM []byte
-	for _, cert := range certs {
-		if cert == nil {
-			continue
-		}
-		p := pem.EncodeToMemory(&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: cert.Raw,
-		})
-		certsPEM = append(certsPEM, p...)
-	}
-	return r.WriteFile(path, certsPEM, 0644)
 }

--- a/tools/geneos/internal/instance/tls.go
+++ b/tools/geneos/internal/instance/tls.go
@@ -24,10 +24,8 @@ package instance
 
 import (
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,12 +42,12 @@ import (
 //
 // this also creates a new private key
 //
-// skip if certificate exists (no expiry check)
+// skip if certificate exists and is valid
 func CreateCert(c geneos.Instance) (err error) {
 	tlsDir := filepath.Join(geneos.Root(), "tls")
 
 	// skip if we can load an existing certificate
-	if _, err = ReadCert(c); err == nil {
+	if _, _, err = ReadCert(c); err == nil {
 		return
 	}
 
@@ -81,12 +79,12 @@ func CreateCert(c geneos.Instance) (err error) {
 	if err != nil {
 		return
 	}
-	intrKey, err := geneos.LOCAL.ReadKey(filepath.Join(tlsDir, geneos.SigningCertFile+".key"))
+	intrKey, err := config.ReadKey(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".key"))
 	if err != nil {
 		return
 	}
 
-	cert, key, err := CreateCertKey(&template, intrCert, intrKey, nil)
+	cert, key, err := config.CreateCertKey(&template, intrCert, intrKey, nil)
 	if err != nil {
 		return
 	}
@@ -104,106 +102,6 @@ func CreateCert(c geneos.Instance) (err error) {
 	return
 }
 
-// CreateRootCA creates a new root certificate and private key and saves
-// it in dir. If overwrite is true then any existing certificate and key
-// is overwritten.
-func CreateRootCA(dir string, overwrite bool) (err error) {
-	// create rootCA.pem / rootCA.key
-	var cert *x509.Certificate
-	rootCertPath := filepath.Join(dir, geneos.RootCAFile+".pem")
-	rootKeyPath := filepath.Join(dir, geneos.RootCAFile+".key")
-
-	if !overwrite {
-		if _, err = ReadRootCert(dir); err == nil {
-			return geneos.ErrExists
-		}
-	}
-	serial, err := rand.Prime(rand.Reader, 64)
-	if err != nil {
-		return
-	}
-	template := &x509.Certificate{
-		SerialNumber: serial,
-		Subject: pkix.Name{
-			CommonName: "geneos root CA",
-		},
-		NotBefore:             time.Now().Add(-60 * time.Second),
-		NotAfter:              time.Now().AddDate(10, 0, 0).Truncate(24 * time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		MaxPathLen:            2,
-	}
-
-	cert, key, err := CreateCertKey(template, template, nil, nil)
-	if err != nil {
-		return
-	}
-
-	if err = geneos.LOCAL.WriteCert(rootCertPath, cert); err != nil {
-		return
-	}
-	if err = geneos.LOCAL.WriteKey(rootKeyPath, key); err != nil {
-		return
-	}
-
-	return
-}
-
-// CreateSigningCert creates a new signing certificate and private key.
-// If overwrite is true than any existing cert and key are overwritten.
-func CreateSigningCert(dir string, overwrite bool) (err error) {
-	var cert *x509.Certificate
-	intrCertPath := filepath.Join(dir, geneos.SigningCertFile+".pem")
-	intrKeyPath := filepath.Join(dir, geneos.SigningCertFile+".key")
-
-	if !overwrite {
-		if _, err = ReadSigningCert(dir); err == nil {
-			return geneos.ErrExists
-		}
-	}
-
-	serial, err := rand.Prime(rand.Reader, 64)
-	if err != nil {
-		return
-	}
-	template := x509.Certificate{
-		SerialNumber: serial,
-		Subject: pkix.Name{
-			CommonName: "geneos intermediate CA",
-		},
-		NotBefore:             time.Now().Add(-60 * time.Second),
-		NotAfter:              time.Now().AddDate(10, 0, 0).Truncate(24 * time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		MaxPathLen:            1,
-	}
-
-	rootCert, err := ReadRootCert(dir)
-	if err != nil {
-		return
-	}
-	rootKey, err := geneos.LOCAL.ReadKey(filepath.Join(dir, geneos.RootCAFile+".key"))
-	if err != nil {
-		return
-	}
-
-	cert, key, err := CreateCertKey(&template, rootCert, rootKey, nil)
-	if err != nil {
-		return
-	}
-
-	if err = geneos.LOCAL.WriteCert(intrCertPath, cert); err != nil {
-		return
-	}
-	if err = geneos.LOCAL.WriteKey(intrKeyPath, key); err != nil {
-		return
-	}
-
-	return
-}
-
 // WriteCert writes the certificate for the instance c
 func WriteCert(c geneos.Instance, cert *x509.Certificate) (err error) {
 	cf := c.Config()
@@ -212,7 +110,7 @@ func WriteCert(c geneos.Instance, cert *x509.Certificate) (err error) {
 		return geneos.ErrInvalidArgs
 	}
 	certfile := c.Type().String() + ".pem"
-	if err = c.Host().WriteCert(filepath.Join(c.Home(), certfile), cert); err != nil {
+	if err = config.WriteCert(c.Host(), filepath.Join(c.Home(), certfile), cert); err != nil {
 		return
 	}
 	if cf.GetString("certificate") == certfile {
@@ -236,7 +134,7 @@ func WriteKey(c geneos.Instance, key *memguard.Enclave) (err error) {
 	}
 
 	keyfile := c.Type().String() + ".key"
-	if err = c.Host().WriteKey(filepath.Join(c.Home(), keyfile), key); err != nil {
+	if err = config.WriteKey(c.Host(), filepath.Join(c.Home(), keyfile), key); err != nil {
 		return
 	}
 	if cf.GetString("privatekey") == keyfile {
@@ -253,25 +151,50 @@ func WriteKey(c geneos.Instance, key *memguard.Enclave) (err error) {
 // ReadRootCert reads the root certificate from the installation
 // directory
 func ReadRootCert(tlsDir string) (cert *x509.Certificate, err error) {
-	return geneos.LOCAL.ReadCert(filepath.Join(tlsDir, geneos.RootCAFile+".pem"))
+	return config.ReadCert(geneos.LOCAL, filepath.Join(tlsDir, geneos.RootCAFile+".pem"))
 }
 
 // ReadSigningCert reads the signing certificate from the installation
 // directory
 func ReadSigningCert(tlsDir string) (cert *x509.Certificate, err error) {
-	return geneos.LOCAL.ReadCert(filepath.Join(tlsDir, geneos.SigningCertFile+".pem"))
+	return config.ReadCert(geneos.LOCAL, filepath.Join(tlsDir, geneos.SigningCertFile+".pem"))
 }
 
 // ReadCert reads the instance certificate
-func ReadCert(c geneos.Instance) (cert *x509.Certificate, err error) {
+func ReadCert(c geneos.Instance) (cert *x509.Certificate, valid bool, err error) {
 	if c.Type() == nil {
-		return nil, geneos.ErrInvalidArgs
+		return nil, false, geneos.ErrInvalidArgs
 	}
 
 	if Filename(c, "certificate") == "" {
-		return nil, os.ErrNotExist
+		return nil, false, os.ErrNotExist
 	}
-	return c.Host().ReadCert(Filepath(c, "certificate"))
+	cert, err = config.ReadCert(c.Host(), Filepath(c, "certificate"))
+
+	// validate against chain.pem on the same host, expiry etc.
+	if chain, err := c.Host().ReadFile(c.Host().Filepath("tls", "chain.pem")); err == nil {
+		cp := x509.NewCertPool()
+		cp.AppendCertsFromPEM(chain)
+
+		opts := x509.VerifyOptions{
+			Roots: cp,
+		}
+
+		if _, err = cert.Verify(opts); err == nil { // return if no error
+			log.Debug().Msgf("cert %q verified", cert.Subject.CommonName)
+			return cert, true, err
+		}
+	}
+
+	// if failed against internal certs, try system ones
+	if _, err = cert.Verify(x509.VerifyOptions{}); err == nil { // return if no error
+		valid = true
+		log.Debug().Msgf("cert %q verified", cert.Subject.CommonName)
+		return
+	}
+
+	log.Debug().Msgf("cert %q NOT verified", cert.Subject.CommonName)
+	return
 }
 
 // ReadKey reads the instance RSA private key
@@ -280,68 +203,5 @@ func ReadKey(c geneos.Instance) (key *memguard.Enclave, err error) {
 		return nil, geneos.ErrInvalidArgs
 	}
 
-	return c.Host().ReadKey(Abs(c, c.Config().GetString("privatekey")))
-}
-
-// NewPrivateKey returns a PKCS1 encoded RSA Private Key as an enclave. It is
-// not PEM encoded.
-func NewPrivateKey() *memguard.Enclave {
-	certKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		log.Fatal().Err(err).Msg("")
-	}
-
-	return memguard.NewEnclave(x509.MarshalPKCS1PrivateKey(certKey))
-}
-
-// CreateCertKey is a wrapper to create a new certificate given the
-// signing cert and private key and an optional private key to (re)use
-// for the created certificate itself. returns a certificate and private
-// key. Keys are in PEM format so need parsing after unsealing.
-func CreateCertKey(template, parent *x509.Certificate, parentKeyPEM, existingKeyPEM *memguard.Enclave) (cert *x509.Certificate, keyPEM *memguard.Enclave, err error) {
-	var certBytes []byte
-	var certKey *rsa.PrivateKey
-
-	if template != parent && parentKeyPEM == nil {
-		err = errors.New("parent key empty but not self-signing")
-		return
-	}
-
-	keyPEM = existingKeyPEM
-	if keyPEM == nil {
-		keyPEM = NewPrivateKey()
-	}
-
-	l, _ := keyPEM.Open()
-	if certKey, err = x509.ParsePKCS1PrivateKey(l.Bytes()); err != nil {
-		keyPEM = nil
-		return
-	}
-
-	signingKey := certKey
-	certPubKey := &certKey.PublicKey
-
-	if parentKeyPEM != nil {
-		pk, _ := parentKeyPEM.Open()
-		if signingKey, err = x509.ParsePKCS1PrivateKey(pk.Bytes()); err != nil {
-			keyPEM = nil
-			return
-		}
-		pk.Destroy()
-	}
-
-	if certBytes, err = x509.CreateCertificate(rand.Reader, template, parent, certPubKey, signingKey); err != nil {
-		keyPEM = nil
-		l.Destroy()
-		return
-	}
-
-	if cert, err = x509.ParseCertificate(certBytes); err != nil {
-		keyPEM = nil
-		l.Destroy()
-		return
-	}
-
-	keyPEM = l.Seal()
-	return
+	return config.ReadKey(c.Host(), Abs(c, c.Config().GetString("privatekey")))
 }


### PR DESCRIPTION
Partially addresses #98

* move non-instance TLS functions to the non-internal config package
* add options to `tls new` to create non-instance certs, subject to change
* change comments about cert expiry
* update help text