### PR TITLE
Combine the netprobe types in the base hierarchy

### DIFF
--- a/tools/geneos/cmd/_docs/migrate.md
+++ b/tools/geneos/cmd/_docs/migrate.md
@@ -1,8 +1,9 @@
-By default the `migrate` command will convert legacy `.rc` format files
-to JSON and named the old file to end `.rc.orig`. The `revert` command
-can be used to restore these backup files. If you run a full clean
-(`geneos clean -F`) then it is likely these backup files will be
-removed.
+By default the `migrate` command will move instances from old
+directories to newer ones (e.g. sans from san/sans to netprobe/sans) and
+also convert legacy `.rc` format files to JSON and named the old file to
+end `.rc.orig`. The `revert` command can be used to restore these backup
+files. If you run a full clean (`geneos clean -F`) then it is likely
+these backup files will be removed.
 
 The `--executables`/`-X` option instead creates symbolic links in the
 ${GENEOS_HOME}/bin directory for names that match the original `ctl`

--- a/tools/geneos/cmd/add.go
+++ b/tools/geneos/cmd/add.go
@@ -135,9 +135,10 @@ func AddInstance(ct *geneos.Component, addCmdExtras instance.ExtraConfigValues, 
 	}
 	instance.SetExtendedValues(c, addCmdExtras)
 	cf.SetKeyValues(items...)
+	log.Debug().Msgf("savedir=%s", instance.ParentDirectory(c))
 	if err = cf.Save(c.Type().String(),
 		config.Host(c.Host()),
-		config.SaveDir(c.Type().InstancesDir(c.Host())),
+		config.SaveDir(instance.ParentDirectory(c)),
 		config.SetAppName(c.Name()),
 	); err != nil {
 		return

--- a/tools/geneos/cmd/aescmd/new.go
+++ b/tools/geneos/cmd/aescmd/new.go
@@ -135,7 +135,7 @@ func aesNewSetInstance(c geneos.Instance, params []string) (err error) {
 	} else {
 		err = c.Config().Save(c.Type().String(),
 			config.Host(c.Host()),
-			config.SaveDir(c.Type().InstancesDir(c.Host())),
+			config.SaveDir(instance.ParentDirectory(c)),
 			config.SetAppName(c.Name()),
 		)
 	}

--- a/tools/geneos/cmd/aescmd/set.go
+++ b/tools/geneos/cmd/aescmd/set.go
@@ -157,7 +157,7 @@ func aesSetAESInstance(c geneos.Instance, params []string) (err error) {
 	} else {
 		err = cf.Save(c.Type().String(),
 			config.Host(c.Host()),
-			config.SaveDir(c.Type().InstancesDir(c.Host())),
+			config.SaveDir(instance.ParentDirectory(c)),
 			config.SetAppName(c.Name()),
 		)
 	}

--- a/tools/geneos/cmd/initcmd/templates.go
+++ b/tools/geneos/cmd/initcmd/templates.go
@@ -69,7 +69,7 @@ func initTemplates(h *geneos.Host, options ...geneos.Options) (err error) {
 		if len(ct.Templates) == 0 {
 			continue
 		}
-		templateDir := h.Filepath(ct.Name, "templates")
+		templateDir := h.Filepath(ct, "templates")
 		h.MkdirAll(templateDir, 0775)
 
 		for _, t := range ct.Templates {

--- a/tools/geneos/cmd/protect.go
+++ b/tools/geneos/cmd/protect.go
@@ -74,7 +74,7 @@ func protectInstance(c geneos.Instance, params []string) (err error) {
 	} else {
 		err = cf.Save(c.Type().String(),
 			config.Host(c.Host()),
-			config.SaveDir(c.Type().InstancesDir(c.Host())),
+			config.SaveDir(instance.ParentDirectory(c)),
 			config.SetAppName(c.Name()),
 		)
 	}

--- a/tools/geneos/cmd/set.go
+++ b/tools/geneos/cmd/set.go
@@ -101,7 +101,7 @@ func setInstance(c geneos.Instance, params []string) (err error) {
 	} else {
 		err = cf.Save(c.Type().String(),
 			config.Host(c.Host()),
-			config.SaveDir(c.Type().InstancesDir(c.Host())),
+			config.SaveDir(instance.ParentDirectory(c)),
 			config.SetAppName(c.Name()),
 		)
 	}

--- a/tools/geneos/docs/geneos_migrate.md
+++ b/tools/geneos/docs/geneos_migrate.md
@@ -6,11 +6,12 @@ Migrate Instance Configurations
 geneos migrate [TYPE] [NAME...] [flags]
 ```
 
-By default the `migrate` command will convert legacy `.rc` format files
-to JSON and named the old file to end `.rc.orig`. The `revert` command
-can be used to restore these backup files. If you run a full clean
-(`geneos clean -F`) then it is likely these backup files will be
-removed.
+By default the `migrate` command will move instances from old
+directories to newer ones (e.g. sans from san/sans to netprobe/sans) and
+also convert legacy `.rc` format files to JSON and named the old file to
+end `.rc.orig`. The `revert` command can be used to restore these backup
+files. If you run a full clean (`geneos clean -F`) then it is likely
+these backup files will be removed.
 
 The `--executables`/`-X` option instead creates symbolic links in the
 ${GENEOS_HOME}/bin directory for names that match the original `ctl`

--- a/tools/geneos/internal/instance/ac2/ac2.go
+++ b/tools/geneos/internal/instance/ac2/ac2.go
@@ -77,9 +77,9 @@ const (
 var ac2jarRE = regexp.MustCompile(`^` + ac2prefix + `(.+)` + ac2suffix)
 
 var ac2Files = []string{
-	"ActiveConsole.gci",
-	"log4j2.properties",
-	"defaultws.dwx",
+	// "ActiveConsole.gci",
+	// "log4j2.properties",
+	// "defaultws.dwx",
 }
 
 type AC2s instance.Instance
@@ -109,6 +109,8 @@ func New(name string) geneos.Instance {
 	if err := instance.SetDefaults(c, local); err != nil {
 		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	ac2s.Store(r.FullName(local), c)
 	return c
 }
@@ -176,7 +178,7 @@ func (n *AC2s) Add(tmpl string, port uint16) (err error) {
 
 	if err = n.Config().Save(n.Type().String(),
 		config.Host(n.Host()),
-		config.SaveDir(n.Type().InstancesDir(n.Host())),
+		config.SaveDir(instance.ParentDirectory(n)),
 		config.SetAppName(n.Name()),
 	); err != nil {
 		return

--- a/tools/geneos/internal/instance/ca3/ca3.go
+++ b/tools/geneos/internal/instance/ca3/ca3.go
@@ -42,6 +42,7 @@ var CA3 = geneos.Component{
 	LegacyPrefix:     "",
 	RelatedTypes:     []*geneos.Component{&netprobe.Netprobe},
 	ComponentMatches: []string{"ca3", "collection-agent", "ca3s", "collector"},
+	ParentType:       &netprobe.Netprobe,
 	RealComponent:    true,
 	DownloadBase:     geneos.DownloadBases{Resources: "Netprobe", Nexus: "geneos-netprobe"},
 	PortRange:        "CA3PortRange",
@@ -66,7 +67,8 @@ var CA3 = geneos.Component{
 	},
 	Directories: []string{
 		"packages/ca3",
-		"ca3/ca3s",
+		"netprobe/netprobes_shared",
+		"netprobe/ca3s",
 	},
 	GetPID: getPID,
 }
@@ -110,6 +112,8 @@ func New(name string) geneos.Instance {
 	if err := instance.SetDefaults(c, local); err != nil {
 		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	ca3s.Store(r.FullName(local), c)
 	return c
 }
@@ -176,7 +180,7 @@ func (n *CA3s) Add(tmpl string, port uint16) (err error) {
 
 	if err = n.Config().Save(n.Type().String(),
 		config.Host(n.Host()),
-		config.SaveDir(n.Type().InstancesDir(n.Host())),
+		config.SaveDir(instance.ParentDirectory(n)),
 		config.SetAppName(n.Name()),
 	); err != nil {
 		return

--- a/tools/geneos/internal/instance/copy.go
+++ b/tools/geneos/internal/instance/copy.go
@@ -85,7 +85,7 @@ func CopyInstance(ct *geneos.Component, source, destination string, move bool) (
 	if ct == nil {
 		for _, t := range geneos.RealComponents() {
 			if err = CopyInstance(t, source, destination, move); err != nil {
-				fmt.Println("Error:", err)
+				log.Debug().Err(err).Msg("")
 				continue
 			}
 		}
@@ -168,7 +168,7 @@ func CopyInstance(ct *geneos.Component, source, destination string, move bool) (
 		}
 	}(src.String(), src.Host(), src.Home(), dst)
 
-	// update *Home manually, as it's not just the prefix
+	// XXX update *Home manually, as it's not just the prefix
 	newdst.Config().Set("home", filepath.Join(dst.Type().InstancesDir(dHost), dName))
 
 	if src.Host() == dHost {

--- a/tools/geneos/internal/instance/fileagent/fileagent.go
+++ b/tools/geneos/internal/instance/fileagent/fileagent.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package fileagent
 
 import (
+	"path/filepath"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -111,8 +112,10 @@ func New(name string) geneos.Instance {
 	c.InstanceHost = r
 	c.Component = &FileAgent
 	if err := instance.SetDefaults(c, local); err != nil {
-		log.Fatal().Err(err).Msgf("%s setDefaults()")
+		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	fileagents.Store(r.FullName(local), c)
 	return c
 }
@@ -177,7 +180,7 @@ func (n *FileAgents) Add(tmpl string, port uint16) (err error) {
 
 	if err = n.Config().Save(n.Type().String(),
 		config.Host(n.Host()),
-		config.SaveDir(n.Type().InstancesDir(n.Host())),
+		config.SaveDir(instance.ParentDirectory(n)),
 		config.SetAppName(n.Name()),
 	); err != nil {
 		log.Fatal().Err(err).Msg("")

--- a/tools/geneos/internal/instance/gateway/gateway.go
+++ b/tools/geneos/internal/instance/gateway/gateway.go
@@ -140,8 +140,10 @@ func New(name string) geneos.Instance {
 	g.Component = &Gateway
 	g.InstanceHost = h
 	if err := instance.SetDefaults(g, local); err != nil {
-		log.Fatal().Err(err).Msgf("%s setDefaults()")
+		log.Fatal().Err(err).Msgf("%s setDefaults()", g)
 	}
+	// set the home dir based on where it might be, default to one above
+	g.Config().Set("home", filepath.Join(instance.ParentDirectory(g), local))
 	gateways.Store(h.FullName(local), g)
 	return g
 }
@@ -216,9 +218,10 @@ func (g *Gateways) Add(template string, port uint16) (err error) {
 	cf.Set("includes", make(map[int]string))
 
 	// try to save config early
+	log.Debug().Msgf("dir: %s", instance.ParentDirectory(g))
 	if err = g.Config().Save(g.Type().String(),
 		config.Host(g.Host()),
-		config.SaveDir(g.Type().InstancesDir(g.Host())),
+		config.SaveDir(instance.ParentDirectory(g)),
 		config.SetAppName(g.Name()),
 	); err != nil {
 		log.Fatal().Err(err).Msg("")
@@ -295,7 +298,7 @@ func (g *Gateways) Rebuild(initial bool) (err error) {
 	if changed {
 		if err = g.Config().Save(g.Type().String(),
 			config.Host(g.Host()),
-			config.SaveDir(g.Type().InstancesDir(g.Host())),
+			config.SaveDir(instance.ParentDirectory(g)),
 			config.SetAppName(g.Name()),
 		); err != nil {
 			return

--- a/tools/geneos/internal/instance/licd/licd.go
+++ b/tools/geneos/internal/instance/licd/licd.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package licd
 
 import (
+	"path/filepath"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -105,6 +106,8 @@ func New(name string) geneos.Instance {
 	if err := instance.SetDefaults(c, local); err != nil {
 		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	licds.Store(r.FullName(local), c)
 	return c
 }
@@ -169,7 +172,7 @@ func (l *Licds) Add(tmpl string, port uint16) (err error) {
 
 	if err = l.Config().Save(l.Type().String(),
 		config.Host(l.Host()),
-		config.SaveDir(l.Type().InstancesDir(l.Host())),
+		config.SaveDir(instance.ParentDirectory(l)),
 		config.SetAppName(l.Name()),
 	); err != nil {
 		log.Fatal().Err(err).Msg("")

--- a/tools/geneos/internal/instance/netprobe/netprobe.go
+++ b/tools/geneos/internal/instance/netprobe/netprobe.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package netprobe
 
 import (
+	"path/filepath"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -75,6 +76,7 @@ var Netprobe = geneos.Component{
 	Directories: []string{
 		"packages/netprobe",
 		"netprobe/netprobes",
+		"netprobe/netprobes_shared",
 	},
 }
 
@@ -105,6 +107,8 @@ func New(name string) geneos.Instance {
 	if err := instance.SetDefaults(c, local); err != nil {
 		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	netprobes.Store(r.FullName(local), c)
 	return c
 }
@@ -169,7 +173,7 @@ func (n *Netprobes) Add(tmpl string, port uint16) (err error) {
 
 	if err = n.Config().Save(n.Type().String(),
 		config.Host(n.Host()),
-		config.SaveDir(n.Type().InstancesDir(n.Host())),
+		config.SaveDir(instance.ParentDirectory(n)),
 		config.SetAppName(n.Name()),
 	); err != nil {
 		return

--- a/tools/geneos/internal/instance/tls.go
+++ b/tools/geneos/internal/instance/tls.go
@@ -119,7 +119,7 @@ func WriteCert(c geneos.Instance, cert *x509.Certificate) (err error) {
 
 	return cf.Save(c.Type().String(),
 		config.Host(c.Host()),
-		config.SaveDir(c.Type().InstancesDir(c.Host())),
+		config.SaveDir(ParentDirectory(c)),
 		config.SetAppName(c.Name()),
 	)
 }
@@ -142,7 +142,7 @@ func WriteKey(c geneos.Instance, key *memguard.Enclave) (err error) {
 	cf.Set("privatekey", keyfile)
 	return cf.Save(c.Type().String(),
 		config.Host(c.Host()),
-		config.SaveDir(c.Type().InstancesDir(c.Host())),
+		config.SaveDir(ParentDirectory(c)),
 		config.SetAppName(c.Name()),
 	)
 }

--- a/tools/geneos/internal/instance/webserver/webserver.go
+++ b/tools/geneos/internal/instance/webserver/webserver.go
@@ -110,8 +110,10 @@ func New(name string) geneos.Instance {
 	c.InstanceHost = r
 	c.Component = &Webserver
 	if err := instance.SetDefaults(c, local); err != nil {
-		log.Fatal().Err(err).Msgf("%s setDefaults()")
+		log.Fatal().Err(err).Msgf("%s setDefaults()", c)
 	}
+	// set the home dir based on where it might be, default to one above
+	c.Config().Set("home", filepath.Join(instance.ParentDirectory(c), local))
 	webservers.Store(r.FullName(local), c)
 	return c
 }
@@ -188,7 +190,7 @@ func (w *Webservers) Add(tmpl string, port uint16) (err error) {
 
 	if err = w.Config().Save(w.Type().String(),
 		config.Host(w.Host()),
-		config.SaveDir(w.Type().InstancesDir(w.Host())),
+		config.SaveDir(instance.ParentDirectory(w)),
 		config.SetAppName(w.Name()),
 	); err != nil {
 		return


### PR DESCRIPTION
Fixes #117

* Use `init templates` to first create templates in new directory
* New instances for ca3, san, floating and fa2 will be created under netprobe
* Existing instances will work without change
* Use `migrate` to move instances to new locations
