### PR TITLE
config (viper) tries to read a binary file in the same directory

### DIFF
--- a/integrations/servicenow/cmd/root.go
+++ b/integrations/servicenow/cmd/root.go
@@ -82,7 +82,7 @@ func initConfig() {
 
 	cf, err = config.Load(execname,
 		config.SetAppName("geneos"),
-		config.SetGlobal(),
+		config.UseGlobal(),
 		config.SetConfigFile(conffile))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load configuration")

--- a/pkg/config/files.go
+++ b/pkg/config/files.go
@@ -197,8 +197,8 @@ func Path(name string, options ...FileOptions) string {
 	}
 
 	filename := name
-	if opts.configFileFormat != "" {
-		filename = fmt.Sprintf("%s.%s", filename, opts.configFileFormat)
+	if opts.extension != "" {
+		filename = fmt.Sprintf("%s.%s", filename, opts.extension)
 	}
 	if len(confDirs) > 0 {
 		for _, dir := range confDirs {

--- a/pkg/config/save.go
+++ b/pkg/config/save.go
@@ -45,7 +45,7 @@ func (cf *Config) Save(name string, options ...FileOptions) (err error) {
 	if opts.appname != "" {
 		subdir = opts.appname
 	}
-	path := filepath.Join(opts.dir, subdir, fmt.Sprintf("%s.%s", name, opts.configFileFormat))
+	path := filepath.Join(opts.dir, subdir, fmt.Sprintf("%s.%s", name, opts.extension))
 
 	if opts.configFile != "" {
 		path = opts.configFile

--- a/tools/dv2email/cmd/root.go
+++ b/tools/dv2email/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig() {
 		config.SetAppName("geneos"),
 		config.SetConfigFile(cfgFile),
 		config.MergeSettings(),
-		config.SetFileFormat("yaml"),
+		config.SetFileExtension("yaml"),
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")

--- a/tools/geneos/cmd/aescmd/decode.go
+++ b/tools/geneos/cmd/aescmd/decode.go
@@ -45,7 +45,7 @@ func init() {
 	cmd.UserKeyFile = cmd.DefaultUserKeyfile
 	aesPrevUserKeyFile = config.KeyFile(config.Path("prevkeyfile",
 		config.SetAppName(cmd.Execname),
-		config.SetFileFormat("aes"),
+		config.SetFileExtension("aes"),
 		config.IgnoreWorkingDir(),
 	))
 

--- a/tools/geneos/cmd/root.go
+++ b/tools/geneos/cmd/root.go
@@ -66,7 +66,7 @@ var debug, quiet bool
 // config.Keyfile type
 var DefaultUserKeyfile = config.KeyFile(config.Path("keyfile",
 	config.SetAppName(Execname),
-	config.SetFileFormat("aes"),
+	config.SetFileExtension("aes"),
 	config.IgnoreWorkingDir()),
 )
 
@@ -275,8 +275,8 @@ func initConfig() {
 
 	cf, err := config.Load(Execname,
 		config.SetConfigFile(cfgFile),
-		config.SetGlobal(),
-		config.AddConfigDirs(oldConfDir),
+		config.UseGlobal(),
+		config.AddDirs(oldConfDir),
 		config.MergeSettings(),
 		config.IgnoreWorkingDir(),
 	)

--- a/tools/geneos/internal/instance/config.go
+++ b/tools/geneos/internal/instance/config.go
@@ -131,7 +131,7 @@ func LoadConfig(c geneos.Instance) (err error) {
 
 	cf, err := config.Load(c.Type().Name,
 		config.Host(r),
-		config.LoadDir(filepath.Join(ParentDirectory(c), c.Name())),
+		config.FromDir(filepath.Join(ParentDirectory(c), c.Name())),
 		config.UseDefaults(false),
 		config.MustExist(),
 	)
@@ -143,7 +143,7 @@ func LoadConfig(c geneos.Instance) (err error) {
 		log.Debug().Msgf("also looking in %s", home)
 		cf, err = config.Load(c.Type().Name,
 			config.Host(r),
-			config.LoadDir(home),
+			config.FromDir(home),
 			config.UseDefaults(false),
 			config.MustExist(),
 		)


### PR DESCRIPTION
Fixes #126

* Some options have changed name, more sensible
* Now the full path to each file is built by hand