### PR TITLE
`geneos` Gateway started with `-ssl-certificate` even when not defined

### DIFF
--- a/tools/geneos/internal/instance/config.go
+++ b/tools/geneos/internal/instance/config.go
@@ -256,6 +256,9 @@ func Filepaths(c geneos.Instance, names ...string) (filenames []string) {
 		if filepath.IsAbs(name) {
 			filenames = append(filenames, name)
 		} else {
+			if !cf.IsSet(name) {
+				continue
+			}
 			filename := filepath.Join(dir, cf.GetString(name))
 			// return empty and not a "."
 			if filename == "." {


### PR DESCRIPTION
Fixes #140