### PR TITLE
`tools/geneos` templates loaded from '*' and not '*.gotmpl'

### DIFF
--- a/tools/geneos/cmd/_docs/rebuild.md
+++ b/tools/geneos/cmd/_docs/rebuild.md
@@ -1,11 +1,13 @@
-All matching instances whose TYPE supported templates for configuration file will have them rebuilt depending on the `config.rebuild` setting for each instance.
+All matching instances whose TYPE supported templates for configuration file will have them rebuilt depending on the `config::rebuild` setting for each instance.
 
-The values for the `config.rebuild` option are: `never`, `initial` and `always`. The default value depends on the TYPE; For Gateways it is `initial` and for SANs and Floating Netprobes it is `always`.
+The values for the `config::rebuild` option are: `never`, `initial` and `always`. The default value depends on the TYPE; For Gateways it is `initial` and for SANs and Floating Netprobes it is `always`.
 
-You can force a rebuild for an instance that has the `config.rebuild` set to `initial` by using the `--force`/`-F` option. Instances with a `never` setting are never rebuilt.
+You can force a rebuild for an instance that has the `config::rebuild` set to `initial` by using the `--force`/`-F` option. Instances with a `never` setting are never rebuilt.
 
-The change this use something like `geneos set gateway config.rebuild=always`
+To change this use something like `geneos set gateway MyGateway config::rebuild=always`
 
 Instances will not normally update their settings when the configuration file changes, although there are options for both Gateways and Netprobes to do this, so you can trigger a configuration reload with the `--reload`/`-r` option. This will send the appropriate signal to matching instances regardless of the underlying configuration being updated or not.
 
-The templates use for each TYPE are stored in a `templates/` directory under each TYPE. If you do not have templates because you are adopting an existing installation or you have upgraded the `geneos` program and want updated templates then run `geneos init template` to overwrite existing file with the built-in ones.
+The templates used for each `TYPE` are stored in the `templates/` directory under each `TYPE` directory, e.g `[GENEOS]/gateway/templates`. If you do not have any templates because you are adopting an existing installation then the program will use internal defaults. Use the `geneos init template` command to write out the current templates based on the built-in ones. Only files with the extension `.gotmpl` are treated as templates and directories (and their contents) are ignored.
+
+The rules for how the files are parsed and made available are those for the Go [template.ParseGlob](https://pkg.go.dev/text/template#ParseGlob) function.

--- a/tools/geneos/cmd/initcmd/_docs/templates.md
+++ b/tools/geneos/cmd/initcmd/_docs/templates.md
@@ -1,4 +1,4 @@
-The `geneos` commands contains a number of default template files that are normally written out during initialization of a new installation. In the case of adopting a legacy installation or upgrading the program it might be desirable to extract these template files.
+The `geneos` commands contains embedded template files that are normally written out during initialization of a new installation so that they can be customised if required. In the case of adopting a legacy installation or upgrading the program you should run this command to write-out the current default templates.
 
 This command will overwrite any files with the same name but will not delete other template files that may already exist.
 

--- a/tools/geneos/docs/geneos_init_template.md
+++ b/tools/geneos/docs/geneos_init_template.md
@@ -6,7 +6,7 @@ Initialise or overwrite templates
 geneos init template [flags]
 ```
 
-The `geneos` commands contains a number of default template files that are normally written out during initialization of a new installation. In the case of adopting a legacy installation or upgrading the program it might be desirable to extract these template files.
+The `geneos` commands contains embedded template files that are normally written out during initialization of a new installation so that they can be customised if required. In the case of adopting a legacy installation or upgrading the program you should run this command to write-out the current default templates.
 
 This command will overwrite any files with the same name but will not delete other template files that may already exist.
 

--- a/tools/geneos/docs/geneos_rebuild.md
+++ b/tools/geneos/docs/geneos_rebuild.md
@@ -6,17 +6,19 @@ Rebuild Instance Configurations From Templates
 geneos rebuild [flags] [TYPE] [NAME...]
 ```
 
-All matching instances whose TYPE supported templates for configuration file will have them rebuilt depending on the `config.rebuild` setting for each instance.
+All matching instances whose TYPE supported templates for configuration file will have them rebuilt depending on the `config::rebuild` setting for each instance.
 
-The values for the `config.rebuild` option are: `never`, `initial` and `always`. The default value depends on the TYPE; For Gateways it is `initial` and for SANs and Floating Netprobes it is `always`.
+The values for the `config::rebuild` option are: `never`, `initial` and `always`. The default value depends on the TYPE; For Gateways it is `initial` and for SANs and Floating Netprobes it is `always`.
 
-You can force a rebuild for an instance that has the `config.rebuild` set to `initial` by using the `--force`/`-F` option. Instances with a `never` setting are never rebuilt.
+You can force a rebuild for an instance that has the `config::rebuild` set to `initial` by using the `--force`/`-F` option. Instances with a `never` setting are never rebuilt.
 
-The change this use something like `geneos set gateway config.rebuild=always`
+To change this use something like `geneos set gateway MyGateway config::rebuild=always`
 
 Instances will not normally update their settings when the configuration file changes, although there are options for both Gateways and Netprobes to do this, so you can trigger a configuration reload with the `--reload`/`-r` option. This will send the appropriate signal to matching instances regardless of the underlying configuration being updated or not.
 
-The templates use for each TYPE are stored in a `templates/` directory under each TYPE. If you do not have templates because you are adopting an existing installation or you have upgraded the `geneos` program and want updated templates then run `geneos init template` to overwrite existing file with the built-in ones.
+The templates used for each `TYPE` are stored in the `templates/` directory under each `TYPE` directory, e.g `[GENEOS]/gateway/templates`. If you do not have any templates because you are adopting an existing installation then the program will use internal defaults. Use the `geneos init template` command to write out the current templates based on the built-in ones. Only files with the extension `.gotmpl` are treated as templates and directories (and their contents) are ignored.
+
+The rules for how the files are parsed and made available are those for the Go [template.ParseGlob](https://pkg.go.dev/text/template#ParseGlob) function.
 
 ### Options
 

--- a/tools/geneos/internal/component/gateway/gateway.go
+++ b/tools/geneos/internal/component/gateway/gateway.go
@@ -301,7 +301,7 @@ func (g *Gateways) Rebuild(initial bool) (err error) {
 	}
 
 	return instance.ExecuteTemplate(g,
-		g.Config().GetString("setup"),
+		cf.GetString("setup"),
 		instance.FileOf(g, "config::template"),
 		template)
 }

--- a/tools/geneos/internal/instance/config.go
+++ b/tools/geneos/internal/instance/config.go
@@ -84,7 +84,7 @@ func ExecuteTemplate(c geneos.Instance, p string, name string, defaultTemplate [
 	cf := c.Config()
 
 	t := template.New("").Funcs(fnmap).Option("missingkey=zero")
-	if t, err = t.ParseGlob(c.Host().PathTo(c.Type(), "templates", "*")); err != nil {
+	if t, err = t.ParseGlob(c.Host().PathTo(c.Type(), "templates", "*.gotmpl")); err != nil {
 		t = template.New(name).Funcs(fnmap).Option("missingkey=zero")
 		// if there are no templates, use internal as a fallback
 		log.Warn().Msgf("No templates found in %s, using internal defaults", c.Host().PathTo(c.Type(), "templates"))


### PR DESCRIPTION
Fixes #167