### PR TITLE
`geneos package delete` removes in-use link and updates them

### DIFF
--- a/tools/geneos/cmd/pkgcmd/_docs/uninstall.md
+++ b/tools/geneos/cmd/pkgcmd/_docs/uninstall.md
@@ -1,4 +1,6 @@
-The `package uninstall` commands removes installed Geneos releases and the original downloaded release files. By default all releases that are not used by any enabled or running instance are removed with the exception of the "latest" release.
+# `geneos package uninstall`
+
+The `package uninstall` commands removes installed Geneos releases and downloaded release files. By default all releases that are not used by any enabled or running instance are removed with the exception of the "latest" release.
 
 To keep the downloaded archives (in `${GENEOS}/packages/download`) use the `--keep`/`-k` flag, otherwise **all** files in that directory are removed.
 
@@ -8,10 +10,10 @@ Note that if `TYPE` is for a component type that uses a different underlying rel
 
 To remove releases that are in use by protected instances you must give the `--force` flag.
 
-For each release being removed any running instances will first be stopped and base links will be updated to point to the "latest" version (unless the `--all` flag is used). Any instances stopped will be restarted after all other actions are complete.
+To update releases in use by instances, whether running or not, use the `--update`/`-U` flag. Base links are only updated if this flag is given (and `--force` if any instance using it is marked protected) unless all matching instances are disabled. For each release being removed any running instances will first be stopped and base links will be updated to point to the "latest" version (unless the `--all` flag is used). Any instances stopped will be restarted after all other actions are complete.
 
 If the `-all` flag is passed then all matching releases are removed and all running instances stopped and disabled. This can be used to force a "clean install" of a component or before removal of a Geneos installation on a specific host.
 
 If a host is not selected with the `--host HOST` flags then the uninstall applies to all configured hosts. 
 
-Use `geneos update list` to see which releases are installed.
+Use `geneos package list` to see which releases are installed.

--- a/tools/geneos/docs/geneos_package_uninstall.md
+++ b/tools/geneos/docs/geneos_package_uninstall.md
@@ -1,6 +1,8 @@
 # `geneos package uninstall`
 
-The `package uninstall` commands removes installed Geneos releases and the original downloaded release files. By default all releases that are not used by any enabled or running instance are removed with the exception of the "latest" release.
+# `geneos package uninstall`
+
+The `package uninstall` commands removes installed Geneos releases and downloaded release files. By default all releases that are not used by any enabled or running instance are removed with the exception of the "latest" release.
 
 To keep the downloaded archives (in `${GENEOS}/packages/download`) use the `--keep`/`-k` flag, otherwise **all** files in that directory are removed.
 
@@ -10,13 +12,13 @@ Note that if `TYPE` is for a component type that uses a different underlying rel
 
 To remove releases that are in use by protected instances you must give the `--force` flag.
 
-For each release being removed any running instances will first be stopped and base links will be updated to point to the "latest" version (unless the `--all` flag is used). Any instances stopped will be restarted after all other actions are complete.
+To update releases in use by instances, whether running or not, use the `--update`/`-U` flag. Base links are only updated if this flag is given (and `--force` if any instance using it is marked protected) unless all matching instances are disabled. For each release being removed any running instances will first be stopped and base links will be updated to point to the "latest" version (unless the `--all` flag is used). Any instances stopped will be restarted after all other actions are complete.
 
 If the `-all` flag is passed then all matching releases are removed and all running instances stopped and disabled. This can be used to force a "clean install" of a component or before removal of a Geneos installation on a specific host.
 
 If a host is not selected with the `--host HOST` flags then the uninstall applies to all configured hosts. 
 
-Use `geneos update list` to see which releases are installed.
+Use `geneos package list` to see which releases are installed.
 
 ```text
 geneos package uninstall [flags] [TYPE]
@@ -27,8 +29,9 @@ geneos package uninstall [flags] [TYPE]
 ```text
   -V, --version VERSION   Uninstall VERSION
   -A, --all               Uninstall all releases, stopping and disabling running instances
-  -f, --force             Force uninstall, stopping protected instances first
   -k, --keep              Keep cached downloads
+  -U, --update            Update base links for instances to latest before restarting and removing
+  -f, --force             Force uninstall, stopping protected instances first. Also requires --update
 ```
 
 ## Examples


### PR DESCRIPTION
Fixes #198

Add an `--update` flag that must be used to trigger restarts and updates of instances that match releases that would be removed.