### PR TITLE
Added Teams Workflow webhook URL style

### DIFF
--- a/libraries/libemail/libemail.go
+++ b/libraries/libemail/libemail.go
@@ -60,7 +60,7 @@ var logo []byte
 
 const msTeamsMessageCard = "MessageCard"
 const geneosThemecolor = "#46e1d7"
-const DefaultWebhookURLValidationPattern = `^https:\/\/(?:.*\.webhook|outlook)\.office(?:365)?\.com`
+const DefaultWebhookURLValidationPattern = `^https:\/\/(?:.*\.webhook|outlook|.*\.logic)\.(?:azure|office(?:365)?)\.com`
 const DefaultMsTeamsTimeout = 2000
 
 type msTeamsBasicTextNotifPostData struct {


### PR DESCRIPTION
Added Teams Workflow webhook URL style
Regex updated to allow for links of format

`https://prod-191.westeurope.logic.azure.com:443/workflows/...`

That are now generated as part of a Teams Workflow Webhook:

![image](https://github.com/user-attachments/assets/1d774151-8f7d-4deb-87aa-e962452299d3)

![image](https://github.com/user-attachments/assets/1b1878dd-8b93-4550-90f2-f44c8fe066a4)
