### PR TITLE
Write tests for pkg config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []FileOptions
+		want    *Config
+	}{
+		{
+			name:    "default config",
+			options: nil,
+		},
+		{
+			name:    "with custom delimiter",
+			options: []FileOptions{KeyDelimiter(":")},
+		},
+		{
+			name:    "with app name",
+			options: []FileOptions{SetAppName("testapp")},
+		},
+		{
+			name:    "with env prefix",
+			options: []FileOptions{WithEnvs("TEST", "_")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := New(tt.options...)
+			if got == nil {
+				t.Fatal("New() returned nil")
+			}
+			if got.Viper == nil {
+				t.Error("New() returned Config with nil Viper")
+			}
+			if got.mutex == nil {
+				t.Error("New() returned Config with nil mutex")
+			}
+		})
+	}
+}
+
+func TestGetConfig(t *testing.T) {
+	// Reset global config for testing
+	ResetConfig()
+	
+	got := GetConfig()
+	if got == nil {
+		t.Fatal("GetConfig() returned nil")
+	}
+	if got.Viper == nil {
+		t.Error("GetConfig() returned Config with nil Viper")
+	}
+
+	// Test that it returns the same instance
+	got2 := GetConfig()
+	if got != got2 {
+		t.Error("GetConfig() should return the same instance")
+	}
+}
+
+func TestResetConfig(t *testing.T) {
+	// Set some values in global config
+	global.Set("test.key", "test.value")
+	original := GetConfig()
+
+	// Reset config
+	ResetConfig()
+	
+	// Should be a different instance but preserve settings
+	newConfig := GetConfig()
+	if original == newConfig {
+		t.Error("ResetConfig() should create a new instance")
+	}
+	
+	if newConfig.GetString("test.key") != "test.value" {
+		t.Error("ResetConfig() should preserve existing settings")
+	}
+}
+
+func TestAppConfigDir(t *testing.T) {
+	config := New(SetAppName("testapp"))
+	dir := config.AppConfigDir()
+	
+	if dir == "" {
+		t.Error("AppConfigDir() returned empty string")
+	}
+	
+	if !strings.Contains(dir, "testapp") {
+		t.Errorf("AppConfigDir() = %q, should contain 'testapp'", dir)
+	}
+}
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name      string
+		delimiter string
+		parts     []string
+		want      string
+	}{
+		{
+			name:      "default delimiter",
+			delimiter: ".",
+			parts:     []string{"a", "b", "c"},
+			want:      "a.b.c",
+		},
+		{
+			name:      "custom delimiter",
+			delimiter: ":",
+			parts:     []string{"x", "y", "z"},
+			want:      "x:y:z",
+		},
+		{
+			name:      "single part",
+			delimiter: ".",
+			parts:     []string{"single"},
+			want:      "single",
+		},
+		{
+			name:      "empty parts",
+			delimiter: ".",
+			parts:     []string{},
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := New(KeyDelimiter(tt.delimiter))
+			got := config.Join(tt.parts...)
+			if got != tt.want {
+				t.Errorf("Join() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDelimiter(t *testing.T) {
+	tests := []struct {
+		name      string
+		delimiter string
+	}{
+		{"default", "."},
+		{"colon", ":"},
+		{"underscore", "_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config *Config
+			if tt.delimiter == "." {
+				config = New()
+			} else {
+				config = New(KeyDelimiter(tt.delimiter))
+			}
+			
+			got := config.Delimiter()
+			if got != tt.delimiter {
+				t.Errorf("Delimiter() = %q, want %q", got, tt.delimiter)
+			}
+		})
+	}
+}
+
+func TestSub(t *testing.T) {
+	config := New()
+	config.Set("database.host", "localhost")
+	config.Set("database.port", 5432)
+	config.Set("database.ssl.enabled", true)
+	
+	sub := config.Sub("database")
+	if sub == nil {
+		t.Fatal("Sub() returned nil")
+	}
+	
+	if sub.GetString("host") != "localhost" {
+		t.Errorf("Sub config host = %q, want 'localhost'", sub.GetString("host"))
+	}
+	
+	if sub.GetInt("port") != 5432 {
+		t.Errorf("Sub config port = %d, want 5432", sub.GetInt("port"))
+	}
+	
+	// Test sub of sub
+	sslSub := sub.Sub("ssl")
+	if !sslSub.GetBool("enabled") {
+		t.Error("Sub of sub should return correct value")
+	}
+	
+	// Test non-existent key returns empty config, not nil
+	emptySub := config.Sub("nonexistent")
+	if emptySub == nil {
+		t.Error("Sub() with non-existent key should return empty config, not nil")
+	}
+}
+
+func TestConfigSetGet(t *testing.T) {
+	config := New()
+	
+	// Test string
+	config.Set("string.key", "test value")
+	if got := config.GetString("string.key"); got != "test value" {
+		t.Errorf("GetString() = %q, want 'test value'", got)
+	}
+	
+	// Test int
+	config.Set("int.key", 42)
+	if got := config.GetInt("int.key"); got != 42 {
+		t.Errorf("GetInt() = %d, want 42", got)
+	}
+	
+	// Test bool
+	config.Set("bool.key", true)
+	if got := config.GetBool("bool.key"); got != true {
+		t.Errorf("GetBool() = %t, want true", got)
+	}
+	
+	// Test slice
+	testSlice := []string{"a", "b", "c"}
+	config.Set("slice.key", testSlice)
+	if got := config.GetStringSlice("slice.key"); len(got) != 3 || got[0] != "a" {
+		t.Errorf("GetStringSlice() = %v, want %v", got, testSlice)
+	}
+}
+
+func TestConfigMerge(t *testing.T) {
+	config1 := New()
+	config1.Set("key1", "value1")
+	config1.Set("shared", "from_config1")
+	
+	config2 := New()
+	config2.Set("key2", "value2")
+	config2.Set("shared", "from_config2")
+	
+	// Test merge
+	config1.MergeConfigMap(config2.AllSettings())
+	
+	if config1.GetString("key1") != "value1" {
+		t.Error("Merge should preserve original values")
+	}
+	
+	if config1.GetString("key2") != "value2" {
+		t.Error("Merge should add new values")
+	}
+	
+	if config1.GetString("shared") != "from_config2" {
+		t.Error("Merge should override with new values")
+	}
+}
+
+func TestUserConfigDir(t *testing.T) {
+	// Test with current user
+	dir, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() failed: %v", err)
+	}
+	
+	if dir == "" {
+		t.Error("UserConfigDir() returned empty string")
+	}
+	
+	// Test that the directory is absolute
+	if !filepath.IsAbs(dir) {
+		t.Errorf("UserConfigDir() = %q, should be absolute path", dir)
+	}
+}
+
+func TestConfigWithEnv(t *testing.T) {
+	// Set test environment variable
+	os.Setenv("TEST_CONFIG_VAR", "env_value")
+	defer os.Unsetenv("TEST_CONFIG_VAR")
+	
+	config := New(WithEnvs("TEST", "_"))
+	
+	// Should be able to get env var through config
+	if got := config.GetString("CONFIG.VAR"); got != "env_value" {
+		t.Errorf("GetString() from env = %q, want 'env_value'", got)
+	}
+}
+
+func TestGlobalFunctions(t *testing.T) {
+	// Test that global functions work
+	ResetConfig()
+	
+	// Test Join
+	joined := Join("a", "b", "c")
+	expected := "a.b.c"
+	if joined != expected {
+		t.Errorf("Join() = %q, want %q", joined, expected)
+	}
+	
+	// Test Delimiter
+	delimiter := Delimiter()
+	if delimiter != "." {
+		t.Errorf("Delimiter() = %q, want '.'", delimiter)
+	}
+	
+	// Test AppConfigDir
+	dir := AppConfigDir()
+	// Should not be empty unless there's an error
+	if dir == "" {
+		t.Log("AppConfigDir() returned empty string - might be expected in test environment")
+	}
+}

--- a/pkg/config/credentials_test.go
+++ b/pkg/config/credentials_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright © 2023 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCredentials(t *testing.T) {
+	// Test Credentials struct
+	creds := Credentials{
+		Domain:       "example.com",
+		Username:     "testuser",
+		Password:     "testpass",
+		ClientID:     "client123",
+		ClientSecret: "secret456",
+		Token:        "token789",
+		Renewal:      "renewal123",
+	}
+
+	if creds.Domain != "example.com" {
+		t.Errorf("Domain = %q, want 'example.com'", creds.Domain)
+	}
+
+	if creds.Username != "testuser" {
+		t.Errorf("Username = %q, want 'testuser'", creds.Username)
+	}
+
+	if creds.Password != "testpass" {
+		t.Errorf("Password = %q, want 'testpass'", creds.Password)
+	}
+}
+
+func TestFindCreds(t *testing.T) {
+	config := New()
+
+	// Set up test credentials
+	config.Set("credentials.example.com.username", "user1")
+	config.Set("credentials.example.com.password", "pass1")
+	config.Set("credentials.sub.example.com.username", "user2")
+	config.Set("credentials.sub.example.com.password", "pass2")
+	config.Set("credentials.other.com.username", "user3")
+
+	tests := []struct {
+		name     string
+		path     string
+		wantUser string
+		wantNil  bool
+	}{
+		{
+			name:     "exact match",
+			path:     "example.com",
+			wantUser: "user1",
+		},
+		{
+			name:     "subdomain match",
+			path:     "sub.example.com",
+			wantUser: "user2",
+		},
+		{
+			name:     "longest match",
+			path:     "test.sub.example.com",
+			wantUser: "user2", // Should match sub.example.com, not example.com
+		},
+		{
+			name:    "no match",
+			path:    "nomatch.com",
+			wantNil: true,
+		},
+		{
+			name:    "empty path",
+			path:    "",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := config.FindCreds(tt.path)
+
+			if tt.wantNil {
+				if creds != nil {
+					t.Error("FindCreds() should return nil")
+				}
+				return
+			}
+
+			if creds == nil {
+				t.Fatal("FindCreds() returned nil, expected credentials")
+			}
+
+			if got := creds.GetString("username"); got != tt.wantUser {
+				t.Errorf("FindCreds() username = %q, want %q", got, tt.wantUser)
+			}
+		})
+	}
+}
+
+func TestFindCredsGlobal(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a test config file with credentials
+	configContent := `{
+		"credentials": {
+			"global.example.com": {
+				"username": "globaluser",
+				"password": "globalpass"
+			}
+		}
+	}`
+
+	configFile := filepath.Join(tempDir, "creds.json")
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	// Test global FindCreds function
+	creds := FindCreds("global.example.com", SetConfigFile(configFile))
+	if creds == nil {
+		t.Fatal("FindCreds() global returned nil")
+	}
+
+	if got := creds.GetString("username"); got != "globaluser" {
+		t.Errorf("Global FindCreds() username = %q, want 'globaluser'", got)
+	}
+}
+
+func TestAddCreds(t *testing.T) {
+	tempDir := t.TempDir()
+
+	creds := Credentials{
+		Domain:   "test.example.com",
+		Username: "newuser",
+		Password: "newpass",
+		Token:    "newtoken",
+	}
+
+	err := AddCreds(creds, AddDirs(tempDir), SetAppName("testapp"))
+	if err != nil {
+		t.Fatalf("AddCreds() failed: %v", err)
+	}
+
+	// Verify credentials were saved by trying to find them
+	foundCreds := FindCreds("test.example.com", AddDirs(tempDir), SetAppName("testapp"))
+	if foundCreds == nil {
+		t.Fatal("AddCreds() did not save credentials properly")
+	}
+
+	if got := foundCreds.GetString("username"); got != "newuser" {
+		t.Errorf("Added credentials username = %q, want 'newuser'", got)
+	}
+
+	if got := foundCreds.GetString("password"); got != "newpass" {
+		t.Errorf("Added credentials password = %q, want 'newpass'", got)
+	}
+
+	if got := foundCreds.GetString("token"); got != "newtoken" {
+		t.Errorf("Added credentials token = %q, want 'newtoken'", got)
+	}
+}
+
+func TestDeleteCreds(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// First add some credentials
+	creds := Credentials{
+		Domain:   "delete.example.com",
+		Username: "deleteuser",
+		Password: "deletepass",
+	}
+
+	err := AddCreds(creds, AddDirs(tempDir), SetAppName("testapp"))
+	if err != nil {
+		t.Fatalf("AddCreds() setup failed: %v", err)
+	}
+
+	// Verify they exist
+	foundCreds := FindCreds("delete.example.com", AddDirs(tempDir), SetAppName("testapp"))
+	if foundCreds == nil {
+		t.Fatal("Setup: credentials not found after adding")
+	}
+
+	// Delete them
+	err = DeleteCreds("delete.example.com", AddDirs(tempDir), SetAppName("testapp"))
+	if err != nil {
+		t.Fatalf("DeleteCreds() failed: %v", err)
+	}
+
+	// Verify they're gone
+	foundCreds = FindCreds("delete.example.com", AddDirs(tempDir), SetAppName("testapp"))
+	if foundCreds != nil {
+		t.Error("DeleteCreds() did not remove credentials")
+	}
+}
+
+func TestDeleteAllCreds(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Add multiple credentials
+	creds1 := Credentials{
+		Domain:   "all1.example.com",
+		Username: "user1",
+	}
+	creds2 := Credentials{
+		Domain:   "all2.example.com",
+		Username: "user2",
+	}
+
+	options := []FileOptions{AddDirs(tempDir), SetAppName("testapp")}
+
+	err := AddCreds(creds1, options...)
+	if err != nil {
+		t.Fatalf("AddCreds() 1 failed: %v", err)
+	}
+
+	err = AddCreds(creds2, options...)
+	if err != nil {
+		t.Fatalf("AddCreds() 2 failed: %v", err)
+	}
+
+	// Verify both exist
+	if FindCreds("all1.example.com", options...) == nil {
+		t.Fatal("Setup: first credentials not found")
+	}
+	if FindCreds("all2.example.com", options...) == nil {
+		t.Fatal("Setup: second credentials not found")
+	}
+
+	// Delete all
+	err = DeleteAllCreds(options...)
+	if err != nil {
+		t.Fatalf("DeleteAllCreds() failed: %v", err)
+	}
+
+	// Verify both are gone
+	if FindCreds("all1.example.com", options...) != nil {
+		t.Error("DeleteAllCreds() did not remove first credentials")
+	}
+	if FindCreds("all2.example.com", options...) != nil {
+		t.Error("DeleteAllCreds() did not remove second credentials")
+	}
+}
+
+func TestCredentialsWithNilConfig(t *testing.T) {
+	var config *Config = nil
+
+	// FindCreds should handle nil config gracefully
+	creds := config.FindCreds("any.domain.com")
+	if creds != nil {
+		t.Error("FindCreds() with nil config should return nil")
+	}
+}
+
+func TestCredentialsEmptyDomain(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Test adding credentials with empty domain
+	creds := Credentials{
+		Domain:   "",
+		Username: "emptyuser",
+	}
+
+	err := AddCreds(creds, AddDirs(tempDir))
+	// This might fail or succeed depending on implementation
+	// The test is mainly to ensure it doesn't panic
+	if err != nil {
+		t.Logf("AddCreds() with empty domain failed as expected: %v", err)
+	}
+}
+
+func TestCredentialsComplexDomains(t *testing.T) {
+	config := New()
+
+	// Set up credentials for various domain patterns
+	config.Set("credentials.api.service.company.com.username", "api_user")
+	config.Set("credentials.service.company.com.username", "service_user")
+	config.Set("credentials.company.com.username", "company_user")
+	config.Set("credentials.localhost:8080.username", "local_user")
+	config.Set("credentials.192.168.1.100.username", "ip_user")
+
+	tests := []struct {
+		name     string
+		domain   string
+		wantUser string
+	}{
+		{
+			name:     "full API domain",
+			domain:   "api.service.company.com",
+			wantUser: "api_user",
+		},
+		{
+			name:     "service domain",
+			domain:   "service.company.com",
+			wantUser: "service_user",
+		},
+		{
+			name:     "company domain",
+			domain:   "company.com",
+			wantUser: "company_user",
+		},
+		{
+			name:     "localhost with port",
+			domain:   "localhost:8080",
+			wantUser: "local_user",
+		},
+		{
+			name:     "IP address",
+			domain:   "192.168.1.100",
+			wantUser: "ip_user",
+		},
+		{
+			name:     "subdomain of API",
+			domain:   "v1.api.service.company.com",
+			wantUser: "api_user", // Should match longest prefix
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := config.FindCreds(tt.domain)
+			if creds == nil {
+				t.Fatalf("FindCreds(%q) returned nil", tt.domain)
+			}
+
+			if got := creds.GetString("username"); got != tt.wantUser {
+				t.Errorf("FindCreds(%q) username = %q, want %q", tt.domain, got, tt.wantUser)
+			}
+		})
+	}
+}
+
+func TestCredentialsPartialMatches(t *testing.T) {
+	config := New()
+
+	// Set up some test credentials
+	config.Set("credentials.example.com.username", "example_user")
+	config.Set("credentials.test.example.com.username", "test_user")
+
+	// Test partial domain matching
+	creds := config.FindCreds("sub.test.example.com")
+	if creds == nil {
+		t.Fatal("FindCreds() should find partial match")
+	}
+
+	// Should match the longest available match (test.example.com)
+	if got := creds.GetString("username"); got != "test_user" {
+		t.Errorf("FindCreds() should match longest prefix, got %q, want 'test_user'", got)
+	}
+}
+
+func TestCredentialsWithAllFields(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Test with all credential fields populated
+	fullCreds := Credentials{
+		Domain:       "full.example.com",
+		Username:     "fulluser",
+		Password:     "fullpass",
+		ClientID:     "full_client_id",
+		ClientSecret: "full_client_secret",
+		Token:        "full_token",
+		Renewal:      "full_renewal",
+	}
+
+	err := AddCreds(fullCreds, AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("AddCreds() with full credentials failed: %v", err)
+	}
+
+	// Retrieve and verify all fields
+	retrieved := FindCreds("full.example.com", AddDirs(tempDir))
+	if retrieved == nil {
+		t.Fatal("FindCreds() returned nil for full credentials")
+	}
+
+	if got := retrieved.GetString("username"); got != "fulluser" {
+		t.Errorf("username = %q, want 'fulluser'", got)
+	}
+	if got := retrieved.GetString("password"); got != "fullpass" {
+		t.Errorf("password = %q, want 'fullpass'", got)
+	}
+	if got := retrieved.GetString("client_id"); got != "full_client_id" {
+		t.Errorf("client_id = %q, want 'full_client_id'", got)
+	}
+	if got := retrieved.GetString("client_secret"); got != "full_client_secret" {
+		t.Errorf("client_secret = %q, want 'full_client_secret'", got)
+	}
+	if got := retrieved.GetString("token"); got != "full_token" {
+		t.Errorf("token = %q, want 'full_token'", got)
+	}
+	if got := retrieved.GetString("renewal"); got != "full_renewal" {
+		t.Errorf("renewal = %q, want 'full_renewal'", got)
+	}
+}

--- a/pkg/config/crypto_test.go
+++ b/pkg/config/crypto_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewRandomKeyValues(t *testing.T) {
+	kv := NewRandomKeyValues()
+	if kv == nil {
+		t.Fatal("NewRandomKeyValues() returned nil")
+	}
+
+	if kv.Enclave == nil {
+		t.Error("NewRandomKeyValues() returned KeyValues with nil Enclave")
+	}
+
+	// Test that we can get string representation
+	s := kv.String()
+	if s == "" {
+		t.Error("KeyValues should have string representation")
+	}
+}
+
+func TestNewPlaintext(t *testing.T) {
+	testData := []byte("test password")
+	plaintext := NewPlaintext(testData)
+
+	if plaintext == nil {
+		t.Fatal("NewPlaintext() returned nil")
+	}
+
+	if plaintext.IsNil() {
+		t.Error("NewPlaintext() returned nil plaintext")
+	}
+
+	// Verify content using public methods
+	if plaintext.String() != string(testData) {
+		t.Error("Plaintext content doesn't match input")
+	}
+
+	if !bytes.Equal(plaintext.Bytes(), testData) {
+		t.Error("Plaintext bytes don't match input")
+	}
+}
+
+func TestKeyValuesEncodeDecodeString(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	testString := "Hello, World!"
+
+	// Test encoding
+	encoded, err := kv.EncodeString(testString)
+	if err != nil {
+		t.Fatalf("EncodeString() failed: %v", err)
+	}
+
+	if encoded == "" {
+		t.Error("EncodeString() returned empty string")
+	}
+
+	// Test decoding
+	decoded, err := kv.DecodeString("+encs+"+encoded)
+	if err != nil {
+		t.Fatalf("DecodeString() failed: %v", err)
+	}
+
+	if decoded != testString {
+		t.Errorf("DecodeString() = %q, want %q", decoded, testString)
+	}
+}
+
+func TestKeyValuesEncodeDecodeBytes(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	testData := []byte("Binary data test \x00\x01\x02")
+	plaintext := NewPlaintext(testData)
+
+	// Test encoding
+	encoded, err := kv.Encode(plaintext)
+	if err != nil {
+		t.Fatalf("Encode() failed: %v", err)
+	}
+
+	if len(encoded) == 0 {
+		t.Error("Encode() returned empty slice")
+	}
+
+	// Test decoding
+	decoded, err := kv.Decode(append([]byte("+encs+"), encoded...))
+	if err != nil {
+		t.Fatalf("Decode() failed: %v", err)
+	}
+
+	if !bytes.Equal(decoded, testData) {
+		t.Error("Decoded data doesn't match original")
+	}
+}
+
+func TestKeyValuesEncodePassword(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	password := NewPlaintext([]byte("secret123"))
+
+	encoded, err := kv.Encode(password)
+	if err != nil {
+		t.Fatalf("EncodePassword() failed: %v", err)
+	}
+
+	if len(encoded) == 0 {
+		t.Error("EncodePassword() returned empty data")
+	}
+
+	// Test decoding back
+	decoded, err := kv.DecodeString("+encs+"+string(encoded))
+	if err != nil {
+		t.Fatalf("DecodeString() failed: %v", err)
+	}
+
+	if decoded != "secret123" {
+		t.Error("Decoded password doesn't match original")
+	}
+}
+
+func TestReadKeyValues(t *testing.T) {
+	// Create a key and get its string representation
+	originalKV := NewRandomKeyValues()
+
+	keyData := originalKV.String()
+
+	// Test reading from string reader
+	reader := strings.NewReader(keyData)
+	readKV, err := ReadKeyValues(reader)
+	if err != nil {
+		t.Fatalf("ReadKeyValues() failed: %v", err)
+	}
+
+	if readKV.Enclave == nil {
+		t.Error("ReadKeyValues() returned KeyValues with nil Enclave")
+	}
+
+	// Test that both keys can encode/decode the same data
+	testData := "test encryption"
+
+	encoded1, err := originalKV.EncodeString(testData)
+	if err != nil {
+		t.Fatalf("Original key encoding failed: %v", err)
+	}
+
+	decoded2, err := readKV.DecodeString("+encs+"+encoded1)
+	if err != nil {
+		t.Fatalf("Read key decoding failed: %v", err)
+	}
+
+	if decoded2 != testData {
+		t.Error("Keys don't match - decoding failed")
+	}
+}
+
+func TestKeyValuesWriteRead(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	// Write to buffer
+	var buf bytes.Buffer
+	err := kv.Write(&buf)
+	if err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("Write() produced no output")
+	}
+
+	// Read back
+	readKV, err := ReadKeyValues(&buf)
+	if err != nil {
+		t.Fatalf("ReadKeyValues() failed: %v", err)
+	}
+
+	// Verify they work the same
+	testStr := "test round trip"
+	encoded, err := kv.EncodeString(testStr)
+	if err != nil {
+		t.Fatalf("Encoding failed: %v", err)
+	}
+
+	decoded, err := readKV.DecodeString("+encs+"+encoded)
+	if err != nil {
+		t.Fatalf("Decoding with read key failed: %v", err)
+	}
+
+	if decoded != testStr {
+		t.Error("Round trip encoding/decoding failed")
+	}
+}
+
+func TestKeyValuesInvalidData(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	// Test decoding invalid data
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"invalid prefix", "invalid+data"},
+		{"short data", "+encs+abc"},
+		{"invalid hex", "+encs+invalid hex!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := kv.DecodeString(tt.input)
+			if err == nil {
+				t.Error("DecodeString() should fail with invalid input")
+			}
+		})
+	}
+}
+
+func TestChecksum(t *testing.T) {
+	testData := "test data for checksum"
+	reader := strings.NewReader(testData)
+
+	crc, err := Checksum(reader)
+	if err != nil {
+		t.Fatalf("Checksum() failed: %v", err)
+	}
+
+	if crc == 0 {
+		t.Error("Checksum() returned 0, expected non-zero value")
+	}
+
+	// Test that same data produces same checksum
+	reader2 := strings.NewReader(testData)
+	crc2, err := Checksum(reader2)
+	if err != nil {
+		t.Fatalf("Second Checksum() failed: %v", err)
+	}
+
+	if crc != crc2 {
+		t.Errorf("Checksums don't match: %d != %d", crc, crc2)
+	}
+
+	// Test different data produces different checksum
+	reader3 := strings.NewReader("different data")
+	crc3, err := Checksum(reader3)
+	if err != nil {
+		t.Fatalf("Third Checksum() failed: %v", err)
+	}
+
+	if crc == crc3 {
+		t.Error("Different data should produce different checksum")
+	}
+}
+
+func TestPlaintextString(t *testing.T) {
+	testStr := "test password"
+	plaintext := NewPlaintext([]byte(testStr))
+
+	if plaintext.String() != testStr {
+		t.Errorf("String() = %q, want %q", plaintext.String(), testStr)
+	}
+}
+
+func TestPlaintextBytes(t *testing.T) {
+	testData := []byte("test data")
+	plaintext := NewPlaintext(testData)
+
+	result := plaintext.Bytes()
+	if !bytes.Equal(result, testData) {
+		t.Error("Bytes() doesn't match original data")
+	}
+}
+
+func TestPlaintextNil(t *testing.T) {
+	plaintext := NewPlaintext([]byte("test"))
+
+	if plaintext.IsNil() {
+		t.Error("Plaintext should not be nil initially")
+	}
+
+	// Test nil plaintext
+	var nilPlaintext *Plaintext = nil
+	if !nilPlaintext.IsNil() {
+		t.Error("Nil plaintext should return true for IsNil()")
+	}
+}
+
+func TestKeyValuesWithDifferentData(t *testing.T) {
+	kv := NewRandomKeyValues()
+
+	// Test various data types
+	testCases := []struct {
+		name string
+		data string
+	}{
+		{"simple", "hello"},
+		{"unicode", "Hello 世界 🌍"},
+		{"special chars", "!@#$%^&*()"},
+		{"newlines", "line1\nline2\r\nline3"},
+		// Note: binary data with null bytes may not work well with string encoding
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := kv.EncodeString(tc.data)
+			if err != nil {
+				t.Fatalf("EncodeString() failed: %v", err)
+			}
+
+			decoded, err := kv.DecodeString("+encs+"+encoded)
+			if err != nil {
+				t.Fatalf("DecodeString() failed: %v", err)
+			}
+
+			if decoded != tc.data {
+				t.Errorf("Round trip failed: got %q, want %q", decoded, tc.data)
+			}
+		})
+	}
+}
+
+func TestMultipleKeyValues(t *testing.T) {
+	// Test that different KeyValues instances produce different encrypted output
+	kv1 := NewRandomKeyValues()
+	kv2 := NewRandomKeyValues()
+
+	testData := "same input"
+
+	encoded1, err := kv1.EncodeString(testData)
+	if err != nil {
+		t.Fatalf("First encoding failed: %v", err)
+	}
+
+	encoded2, err := kv2.EncodeString(testData)
+	if err != nil {
+		t.Fatalf("Second encoding failed: %v", err)
+	}
+
+	// Different keys should produce different ciphertext
+	if encoded1 == encoded2 {
+		t.Error("Different keys should produce different ciphertext")
+	}
+
+	// Each key should only be able to decode its own data
+	_, err = kv1.DecodeString("+encs+"+encoded2)
+	if err == nil {
+		t.Error("Key1 should not be able to decode data encrypted with Key2")
+	}
+
+	_, err = kv2.DecodeString("+encs+"+encoded1)
+	if err == nil {
+		t.Error("Key2 should not be able to decode data encrypted with Key1")
+	}
+}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -1,0 +1,579 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandString(t *testing.T) {
+	config := New()
+	config.Set("database.host", "localhost")
+	config.Set("database.port", "5432")
+	config.Set("app.name", "testapp")
+
+	tests := []struct {
+		name     string
+		input    string
+		want     string
+		options  []ExpandOptions
+	}{
+		{
+			name:  "no expansion",
+			input: "plain text",
+			want:  "plain text",
+		},
+		{
+			name:  "config expansion",
+			input: "Host: ${database.host}",
+			want:  "Host: localhost",
+		},
+		{
+			name:  "config prefix expansion",
+			input: "Port: ${config:database.port}",
+			want:  "Port: 5432",
+		},
+		{
+			name:  "multiple expansions",
+			input: "${app.name} runs on ${database.host}:${database.port}",
+			want:  "testapp runs on localhost:5432",
+		},
+		{
+			name:  "non-existent config key",
+			input: "Missing: ${nonexistent.key}",
+			want:  "Missing: ",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "nested braces",
+			input: "Value: ${{nested}}",
+			want:  "Value: ${{nested}}", // Should not expand invalid syntax
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input, tt.options...)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringEnv(t *testing.T) {
+	// Set test environment variables
+	os.Setenv("TEST_VAR", "test_value")
+	os.Setenv("TEST_NUMBER", "42")
+	defer os.Unsetenv("TEST_VAR")
+	defer os.Unsetenv("TEST_NUMBER")
+
+	config := New()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "env expansion",
+			input: "Value: ${env:TEST_VAR}",
+			want:  "Value: test_value",
+		},
+		{
+			name:  "env number",
+			input: "Number: ${env:TEST_NUMBER}",
+			want:  "Number: 42",
+		},
+		{
+			name:  "non-existent env var",
+			input: "Missing: ${env:NONEXISTENT}",
+			want:  "Missing: ",
+		},
+		{
+			name:  "mixed env and config",
+			input: "Env: ${env:TEST_VAR}, Config: ${database.host}",
+			want:  "Env: test_value, Config: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringWithLookupTable(t *testing.T) {
+	config := New()
+
+	lookupTable := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"override": "from_table",
+	}
+
+	// Also set a config value with the same name
+	config.Set("override", "from_config")
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		options []ExpandOptions
+	}{
+		{
+			name:    "lookup table expansion",
+			input:   "Value: ${key1}",
+			want:    "Value: value1",
+			options: []ExpandOptions{LookupTable(lookupTable)},
+		},
+		{
+			name:    "lookup table override",
+			input:   "Override: ${override}",
+			want:    "Override: from_table",
+			options: []ExpandOptions{LookupTable(lookupTable)},
+		},
+		{
+			name:  "no lookup table",
+			input: "Value: ${key1}",
+			want:  "Value: ", // Should fallback to env (which doesn't exist)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input, tt.options...)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create test files
+	testFile := filepath.Join(tempDir, "test.txt")
+	fileContent := "file content here"
+	err := os.WriteFile(testFile, []byte(fileContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	config := New()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		options []ExpandOptions
+	}{
+		{
+			name:  "file expansion",
+			input: "Content: ${" + testFile + "}",
+			want:  "Content: " + fileContent,
+		},
+		{
+			name:  "file:// prefix",
+			input: "Content: ${file://" + testFile + "}",
+			want:  "Content: " + fileContent,
+		},
+		{
+			name:  "non-existent file",
+			input: "Content: ${/nonexistent/file.txt}",
+			want:  "Content: ", // Should return empty on error
+		},
+		{
+			name:    "disabled external lookups",
+			input:   "Content: ${" + testFile + "}",
+			want:    "Content: ", // Should not read file
+			options: []ExpandOptions{ExternalLookups(false)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input, tt.options...)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringWithDefault(t *testing.T) {
+	config := New()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		options []ExpandOptions
+	}{
+		{
+			name:    "empty with default",
+			input:   "",
+			want:    "default_value",
+			options: []ExpandOptions{Default("default_value")},
+		},
+		{
+			name:    "non-empty with default",
+			input:   "actual_value",
+			want:    "actual_value",
+			options: []ExpandOptions{Default("default_value")},
+		},
+		{
+			name:    "expansion with default",
+			input:   "${nonexistent}",
+			want:    "",
+			options: []ExpandOptions{Default("default_value")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input, tt.options...)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringWithTrimSpace(t *testing.T) {
+	config := New()
+	config.Set("test.value", "  trimmed  ")
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		options []ExpandOptions
+	}{
+		{
+			name:    "trim space enabled",
+			input:   "${test.value}",
+			want:    "trimmed",
+			options: []ExpandOptions{TrimSpace(true)},
+		},
+		{
+			name:  "trim space disabled (default)",
+			input: "${test.value}",
+			want:  "  trimmed  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input, tt.options...)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandStringGlobal(t *testing.T) {
+	// Test global ExpandString function
+	ResetConfig()
+	GetConfig().Set("global.test", "global_value")
+
+	input := "Global: ${global.test}"
+	want := "Global: global_value"
+
+	got := ExpandString(input)
+	if got != want {
+		t.Errorf("ExpandString() global = %q, want %q", got, want)
+	}
+}
+
+func TestExpandStringSlice(t *testing.T) {
+	config := New()
+	config.Set("server.host", "localhost")
+	config.Set("server.port", "8080")
+
+	input := []string{
+		"http://${server.host}:${server.port}",
+		"Database: ${database.url}",
+		"Plain text",
+	}
+
+	want := []string{
+		"http://localhost:8080",
+		"Database: ",
+		"Plain text",
+	}
+
+	got := config.ExpandStringSlice(input)
+	if len(got) != len(want) {
+		t.Fatalf("ExpandStringSlice() length = %d, want %d", len(got), len(want))
+	}
+
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("ExpandStringSlice()[%d] = %q, want %q", i, v, want[i])
+		}
+	}
+}
+
+func TestExpandStringSliceGlobal(t *testing.T) {
+	ResetConfig()
+	GetConfig().Set("global.value", "test")
+
+	input := []string{"${global.value}", "static"}
+	want := []string{"test", "static"}
+
+	got := ExpandStringSlice(input)
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("ExpandStringSlice() global[%d] = %q, want %q", i, v, want[i])
+		}
+	}
+}
+
+func TestExpand(t *testing.T) {
+	config := New()
+	config.Set("test.key", "value")
+
+	input := "Test: ${test.key}"
+	want := []byte("Test: value")
+
+	got := config.Expand(input)
+	if string(got) != string(want) {
+		t.Errorf("Expand() = %q, want %q", string(got), string(want))
+	}
+}
+
+func TestExpandGlobal(t *testing.T) {
+	ResetConfig()
+	GetConfig().Set("global.key", "global")
+
+	input := "Global: ${global.key}"
+	want := []byte("Global: global")
+
+	got := Expand(input)
+	if string(got) != string(want) {
+		t.Errorf("Expand() global = %q, want %q", string(got), string(want))
+	}
+}
+
+func TestExpandWithNoExpand(t *testing.T) {
+	config := New()
+	config.Set("test.key", "value")
+
+	input := "Test: ${test.key}"
+	want := "Test: ${test.key}" // Should not expand
+
+	got := config.ExpandString(input, NoExpand())
+	if got != want {
+		t.Errorf("ExpandString() with NoExpand = %q, want %q", got, want)
+	}
+}
+
+func TestExpandComplexScenarios(t *testing.T) {
+	config := New()
+	config.Set("database.host", "db.example.com")
+	config.Set("database.port", 5432)
+	config.Set("app.name", "myapp")
+	config.Set("template", "Welcome to ${app.name}")
+
+	// Set environment variable
+	os.Setenv("STAGE", "production")
+	defer os.Unsetenv("STAGE")
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "nested reference",
+			input: "Message: ${template}",
+			want:  "Message: Welcome to myapp",
+		},
+		{
+			name:  "mixed sources",
+			input: "${app.name} on ${database.host}:${database.port} (${env:STAGE})",
+			want:  "myapp on db.example.com:5432 (production)",
+		},
+		{
+			name:  "URL-like expansion",
+			input: "postgresql://${database.host}:${database.port}/mydb",
+			want:  "postgresql://db.example.com:5432/mydb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input)
+			if got != tt.want {
+				t.Errorf("ExpandString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandToPassword(t *testing.T) {
+	config := New()
+	config.Set("password", "secret123")
+
+	plaintext := config.ExpandToPassword("${password}")
+	if plaintext == nil {
+		t.Fatal("ExpandToPassword() returned nil")
+	}
+
+	// Note: We can't directly test the content without exposing it
+	// This is a basic test to ensure the function doesn't panic
+	if plaintext.IsNil() {
+		t.Error("ExpandToPassword() returned nil plaintext")
+	}
+}
+
+func TestExpandToPasswordGlobal(t *testing.T) {
+	ResetConfig()
+	GetConfig().Set("global.password", "global_secret")
+
+	plaintext := ExpandToPassword("${global.password}")
+	if plaintext == nil {
+		t.Fatal("ExpandToPassword() global returned nil")
+	}
+
+	if plaintext.IsNil() {
+		t.Error("ExpandToPassword() global returned nil plaintext")
+	}
+}
+
+func TestExpandToEnclave(t *testing.T) {
+	config := New()
+	config.Set("secret", "enclave_data")
+
+	enclave := config.ExpandToEnclave("${secret}")
+	if enclave == nil {
+		t.Fatal("ExpandToEnclave() returned nil")
+	}
+
+	// Basic test to ensure the enclave is valid
+	if enclave.Size() == 0 {
+		t.Error("ExpandToEnclave() returned empty enclave")
+	}
+}
+
+func TestExpandToEnclaveGlobal(t *testing.T) {
+	ResetConfig()
+	GetConfig().Set("global.secret", "global_enclave")
+
+	enclave := ExpandToEnclave("${global.secret}")
+	if enclave == nil {
+		t.Fatal("ExpandToEnclave() global returned nil")
+	}
+
+	if enclave.Size() == 0 {
+		t.Error("ExpandToEnclave() global returned empty enclave")
+	}
+}
+
+func TestExpandToLockedBuffer(t *testing.T) {
+	config := New()
+	config.Set("buffer", "locked_data")
+
+	buffer := config.ExpandToLockedBuffer("${buffer}")
+	if buffer == nil {
+		t.Fatal("ExpandToLockedBuffer() returned nil")
+	}
+
+	if buffer.Size() == 0 {
+		t.Error("ExpandToLockedBuffer() returned empty buffer")
+	}
+}
+
+func TestExpandToLockedBufferGlobal(t *testing.T) {
+	ResetConfig()
+	GetConfig().Set("global.buffer", "global_locked")
+
+	buffer := ExpandToLockedBuffer("${global.buffer}")
+	if buffer == nil {
+		t.Fatal("ExpandToLockedBuffer() global returned nil")
+	}
+
+	if buffer.Size() == 0 {
+		t.Error("ExpandToLockedBuffer() global returned empty buffer")
+	}
+}
+
+func TestExpandWithCustomPrefix(t *testing.T) {
+	config := New()
+
+	// Custom prefix function that reverses the string
+	reverseFunc := func(c *Config, s string, trim bool) (string, error) {
+		runes := []rune(s)
+		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+			runes[i], runes[j] = runes[j], runes[i]
+		}
+		return string(runes), nil
+	}
+
+	input := "Reversed: ${reverse:hello}"
+	want := "Reversed: olleh"
+
+	got := config.ExpandString(input, Prefix("reverse", reverseFunc))
+	if got != want {
+		t.Errorf("ExpandString() with custom prefix = %q, want %q", got, want)
+	}
+}
+
+func TestExpandError(t *testing.T) {
+	config := New()
+
+	// Test various error conditions that should result in empty strings
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "malformed syntax",
+			input: "Bad: ${unclosed",
+			want:  "Bad: ${unclosed", // Should not expand malformed syntax
+		},
+		{
+			name:  "empty variable name",
+			input: "Empty: ${}",
+			want:  "Empty: ", // Should expand to empty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ExpandString(tt.input)
+			if got != tt.want {
+				t.Errorf("ExpandString() error case = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/fileoptions_test.go
+++ b/pkg/config/fileoptions_test.go
@@ -1,0 +1,382 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/itrs-group/cordial/pkg/host"
+)
+
+func TestSetAppName(t *testing.T) {
+	config := New(SetAppName("testapp"))
+
+	// Check that the app name is used in config dir
+	appDir := config.AppConfigDir()
+	if !strings.Contains(appDir, "testapp") {
+		t.Errorf("AppConfigDir() should contain app name, got %q", appDir)
+	}
+}
+
+func TestSetConfigFile(t *testing.T) {
+	testFile := "/path/to/config.json"
+	
+	// This is more of a smoke test since the actual file doesn't exist
+	// The option should be accepted without error
+	config := New()
+	
+	// Test that we can create config with file option
+	_ = New(SetConfigFile(testFile))
+	
+	// If we get here without panic, the option was accepted
+	if config == nil {
+		t.Error("Config should not be nil")
+	}
+}
+
+func TestSetFileExtension(t *testing.T) {
+	tests := []string{"json", "yaml", "yml", "toml", "xml"}
+	
+	for _, ext := range tests {
+		t.Run("extension_"+ext, func(t *testing.T) {
+			config := New(SetFileExtension(ext))
+			if config == nil {
+				t.Error("Config should not be nil with extension", ext)
+			}
+		})
+	}
+}
+
+func TestKeyDelimiter(t *testing.T) {
+	tests := []struct {
+		delimiter string
+		parts     []string
+		want      string
+	}{
+		{".", []string{"a", "b", "c"}, "a.b.c"},
+		{":", []string{"x", "y", "z"}, "x:y:z"},
+		{"_", []string{"one", "two"}, "one_two"},
+		{"/", []string{"path", "to", "item"}, "path/to/item"},
+	}
+
+	for _, tt := range tests {
+		t.Run("delimiter_"+tt.delimiter, func(t *testing.T) {
+			config := New(KeyDelimiter(tt.delimiter))
+			got := config.Join(tt.parts...)
+			
+			if got != tt.want {
+				t.Errorf("Join() with delimiter %q = %q, want %q", tt.delimiter, got, tt.want)
+			}
+			
+			if config.Delimiter() != tt.delimiter {
+				t.Errorf("Delimiter() = %q, want %q", config.Delimiter(), tt.delimiter)
+			}
+		})
+	}
+}
+
+func TestWithEnvs(t *testing.T) {
+	config := New(WithEnvs("TEST", "_"))
+	
+	// Basic test - should not panic and should create valid config
+	if config == nil {
+		t.Error("Config with env options should not be nil")
+	}
+	
+	// More detailed testing would require setting actual env vars
+	// which is covered in other test files
+}
+
+func TestAddDirs(t *testing.T) {
+	dirs := []string{"/path1", "/path2", "/path3"}
+	config := New(AddDirs(dirs...))
+	
+	if config == nil {
+		t.Error("Config with added dirs should not be nil")
+	}
+}
+
+func TestFromDir(t *testing.T) {
+	testDir := "/test/directory"
+	config := New(FromDir(testDir))
+	
+	if config == nil {
+		t.Error("Config with FromDir should not be nil")
+	}
+}
+
+func TestIgnoreOptions(t *testing.T) {
+	// Test that ignore options don't break config creation
+	config := New(
+		IgnoreWorkingDir(),
+		IgnoreUserConfDir(),
+		IgnoreSystemDir(),
+	)
+	
+	if config == nil {
+		t.Error("Config with ignore options should not be nil")
+	}
+}
+
+func TestMergeSettings(t *testing.T) {
+	config := New(MergeSettings())
+	
+	if config == nil {
+		t.Error("Config with MergeSettings should not be nil")
+	}
+}
+
+func TestHost(t *testing.T) {
+	localhost := host.Localhost
+	config := New(Host(localhost))
+	
+	if config == nil {
+		t.Error("Config with Host option should not be nil")
+	}
+}
+
+func TestUseGlobal(t *testing.T) {
+	// Save original global
+	originalGlobal := GetConfig()
+	
+	config := New(UseGlobal())
+	
+	// UseGlobal should affect the global config
+	if config == nil {
+		t.Error("Config with UseGlobal should not be nil")
+	}
+	
+	// Restore original for other tests
+	global = originalGlobal
+}
+
+func TestUseDefaults(t *testing.T) {
+	config := New(UseDefaults(true))
+	if config == nil {
+		t.Error("Config with UseDefaults(true) should not be nil")
+	}
+	
+	config2 := New(UseDefaults(false))
+	if config2 == nil {
+		t.Error("Config with UseDefaults(false) should not be nil")
+	}
+}
+
+func TestWithDefaults(t *testing.T) {
+	defaults := []byte(`{"default": {"value": "test"}}`)
+	config := New(WithDefaults(defaults, "json"))
+	
+	if config == nil {
+		t.Error("Config with defaults should not be nil")
+	}
+}
+
+func TestMustExist(t *testing.T) {
+	config := New(MustExist())
+	
+	if config == nil {
+		t.Error("Config with MustExist should not be nil")
+	}
+}
+
+func TestSetConfigReader(t *testing.T) {
+	reader := strings.NewReader(`{"test": "value"}`)
+	config := New(SetConfigReader(reader))
+	
+	if config == nil {
+		t.Error("Config with reader should not be nil")
+	}
+}
+
+func TestDefaultKeyDelimiter(t *testing.T) {
+	// Test setting global default
+	originalDelimiter := "."
+	
+	DefaultKeyDelimiter(":")
+	config := New()
+	
+	if config.Delimiter() != ":" {
+		t.Errorf("Default delimiter should be ':', got %q", config.Delimiter())
+	}
+	
+	// Reset to original
+	DefaultKeyDelimiter(originalDelimiter)
+}
+
+func TestDefaultFileExtension(t *testing.T) {
+	// Test setting global default extension
+	DefaultFileExtension("yaml")
+	
+	// Create config - extension should be used in file operations
+	config := New()
+	if config == nil {
+		t.Error("Config should not be nil after setting default extension")
+	}
+	
+	// Reset to original (json is typically the default)
+	DefaultFileExtension("json")
+}
+
+func TestMultipleOptions(t *testing.T) {
+	// Test combining multiple options
+	config := New(
+		SetAppName("multitest"),
+		KeyDelimiter(":"),
+		SetFileExtension("yaml"),
+		WithEnvs("MULTI", "_"),
+		AddDirs("/test/dir1", "/test/dir2"),
+		UseDefaults(true),
+		IgnoreWorkingDir(),
+	)
+	
+	if config == nil {
+		t.Error("Config with multiple options should not be nil")
+	}
+	
+	// Test that options were applied
+	if config.Delimiter() != ":" {
+		t.Error("Key delimiter option not applied")
+	}
+	
+	appDir := config.AppConfigDir()
+	if !strings.Contains(appDir, "multitest") {
+		t.Error("App name option not applied")
+	}
+}
+
+func TestOptionOrdering(t *testing.T) {
+	// Test that option order doesn't matter
+	config1 := New(
+		SetAppName("order1"),
+		KeyDelimiter("_"),
+	)
+	
+	config2 := New(
+		KeyDelimiter("_"),
+		SetAppName("order1"),
+	)
+	
+	if config1.Delimiter() != config2.Delimiter() {
+		t.Error("Option ordering should not affect delimiter")
+	}
+}
+
+func TestNilOptions(t *testing.T) {
+	// Test that nil options slice works
+	config := New(nil...)
+	
+	if config == nil {
+		t.Error("Config with nil options should not be nil")
+	}
+}
+
+func TestEmptyOptions(t *testing.T) {
+	// Test with no options
+	config := New()
+	
+	if config == nil {
+		t.Error("Config with no options should not be nil")
+	}
+	
+	// Should have default values
+	if config.Delimiter() != "." {
+		t.Errorf("Default delimiter should be '.', got %q", config.Delimiter())
+	}
+}
+
+func TestStopOnInternalDefaultsErrors(t *testing.T) {
+	config := New(StopOnInternalDefaultsErrors())
+	
+	if config == nil {
+		t.Error("Config with StopOnInternalDefaultsErrors should not be nil")
+	}
+}
+
+func TestWatchConfig(t *testing.T) {
+	// Test watch config option
+	notifyFunc := func(event fsnotify.Event) {
+		// Test callback
+	}
+	
+	config := New(WatchConfig(notifyFunc))
+	
+	if config == nil {
+		t.Error("Config with WatchConfig should not be nil")
+	}
+	
+	// Note: Actually triggering the watch would require file system operations
+	// This is mainly testing that the option doesn't break config creation
+}
+
+func TestCombinedFileOptions(t *testing.T) {
+	// Test a realistic combination of file options
+	reader := strings.NewReader(`{"combined": {"test": true}}`)
+	
+	config := New(
+		SetAppName("combined-test"),
+		SetConfigReader(reader),
+		SetFileExtension("json"),
+		UseDefaults(false),
+	)
+	
+	if config == nil {
+		t.Error("Config with combined file options should not be nil")
+	}
+}
+
+func TestFileOptionsValidation(t *testing.T) {
+	// Test various edge cases for options
+	tests := []struct {
+		name    string
+		options []FileOptions
+		valid   bool
+	}{
+		{
+			name:    "empty app name",
+			options: []FileOptions{SetAppName("")},
+			valid:   true, // Should be valid, just uses empty string
+		},
+		{
+			name:    "empty delimiter",
+			options: []FileOptions{KeyDelimiter("")},
+			valid:   true, // Implementation dependent
+		},
+		{
+			name:    "empty extension",
+			options: []FileOptions{SetFileExtension("")},
+			valid:   true, // Should be valid
+		},
+		{
+			name:    "nil reader",
+			options: []FileOptions{SetConfigReader(nil)},
+			valid:   true, // Should handle gracefully
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := New(tt.options...)
+			
+			if tt.valid && config == nil {
+				t.Error("Valid options should create non-nil config")
+			}
+		})
+	}
+}

--- a/pkg/config/files_test.go
+++ b/pkg/config/files_test.go
@@ -1,0 +1,427 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/itrs-group/cordial/pkg/host"
+)
+
+func TestPromoteFile(t *testing.T) {
+	tempDir := t.TempDir()
+	localhost := host.Localhost
+
+	// Create test files
+	file1 := filepath.Join(tempDir, "file1.txt")
+	file2 := filepath.Join(tempDir, "file2.txt")
+	file3 := filepath.Join(tempDir, "file3.txt")
+
+	content1 := "content1"
+	content2 := "content2"
+
+	err := os.WriteFile(file2, []byte(content2), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file2: %v", err)
+	}
+
+	err = os.WriteFile(file3, []byte("content3"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file3: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		paths      []string
+		want       string
+		wantExists bool
+		setup      func()
+	}{
+		{
+			name:       "promote second file to first",
+			paths:      []string{file1, file2, file3},
+			want:       file1,
+			wantExists: true,
+			setup:      func() {},
+		},
+		{
+			name:       "first file already exists",
+			paths:      []string{file1, file2, file3},
+			want:       file1,
+			wantExists: true,
+			setup: func() {
+				os.WriteFile(file1, []byte(content1), 0644)
+			},
+		},
+		{
+			name:       "empty first path",
+			paths:      []string{"", file2, file3},
+			want:       file2,
+			wantExists: true,
+			setup:      func() {},
+		},
+		{
+			name:       "no files exist",
+			paths:      []string{filepath.Join(tempDir, "none1"), filepath.Join(tempDir, "none2")},
+			want:       "",
+			wantExists: false,
+			setup:      func() {},
+		},
+		{
+			name:       "empty paths",
+			paths:      []string{},
+			want:       "",
+			wantExists: false,
+			setup:      func() {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up from previous test
+			os.Remove(file1)
+
+			tt.setup()
+
+			got := PromoteFile(localhost, tt.paths...)
+
+			if got != tt.want {
+				t.Errorf("PromoteFile() = %q, want %q", got, tt.want)
+			}
+
+			if tt.wantExists {
+				if got == "" {
+					return // Skip existence check if no file expected
+				}
+				if _, err := os.Stat(got); os.IsNotExist(err) {
+					t.Errorf("PromoteFile() result file %q should exist", got)
+				}
+			}
+		})
+	}
+}
+
+func TestPromoteFileWithDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	subDir := filepath.Join(tempDir, "subdir")
+	err := os.Mkdir(subDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+
+	localhost := host.Localhost
+
+	// Create test file
+	srcFile := filepath.Join(tempDir, "source.txt")
+	err = os.WriteFile(srcFile, []byte("test content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	// Test promoting to directory
+	result := PromoteFile(localhost, subDir, srcFile)
+
+	// Should move file into the directory
+	if !strings.Contains(result, subDir) {
+		t.Errorf("PromoteFile() with directory should return path in directory, got %q", result)
+	}
+
+	if result != "" {
+		if _, err := os.Stat(result); os.IsNotExist(err) {
+			t.Errorf("Promoted file should exist at %q", result)
+		}
+	}
+}
+
+func TestAbbreviateHome(t *testing.T) {
+	// Get the current user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("Cannot get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "path in home",
+			path: filepath.Join(homeDir, "test", "file.txt"),
+			want: "~/test/file.txt",
+		},
+		{
+			name: "home directory itself",
+			path: homeDir,
+			want: "~",
+		},
+		{
+			name: "path not in home",
+			path: "/usr/local/bin",
+			want: "/usr/local/bin",
+		},
+		{
+			name: "relative path",
+			path: "relative/path",
+			want: "relative/path",
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AbbreviateHome(tt.path)
+			if got != tt.want {
+				t.Errorf("AbbreviateHome() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("Cannot get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "tilde path",
+			path: "~/test/file.txt",
+			want: filepath.Join(homeDir, "test", "file.txt"),
+		},
+		{
+			name: "tilde only",
+			path: "~",
+			want: homeDir,
+		},
+		{
+			name: "tilde with separator",
+			path: "~/",
+			want: homeDir + string(filepath.Separator),
+		},
+		{
+			name: "absolute path",
+			path: "/usr/local/bin",
+			want: "/usr/local/bin",
+		},
+		{
+			name: "relative path",
+			path: "relative/path",
+			want: "relative/path",
+		},
+		{
+			name: "tilde in middle (should not expand)",
+			path: "/path/~/file",
+			want: "/path/~/file",
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandHome(tt.path)
+			if got != tt.want {
+				t.Errorf("ExpandHome() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandHomeBytes(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("Cannot get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path []byte
+		want []byte
+	}{
+		{
+			name: "tilde path",
+			path: []byte("~/test/file.txt"),
+			want: []byte(filepath.Join(homeDir, "test", "file.txt")),
+		},
+		{
+			name: "tilde only",
+			path: []byte("~"),
+			want: []byte(homeDir),
+		},
+		{
+			name: "absolute path",
+			path: []byte("/usr/local/bin"),
+			want: []byte("/usr/local/bin"),
+		},
+		{
+			name: "empty path",
+			path: []byte(""),
+			want: []byte(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandHomeBytes(tt.path)
+			if string(got) != string(tt.want) {
+				t.Errorf("ExpandHomeBytes() = %q, want %q", string(got), string(tt.want))
+			}
+		})
+	}
+}
+
+func TestHomeExpansionRoundTrip(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("Cannot get home directory: %v", err)
+	}
+
+	// Test round trip: expand then abbreviate
+	originalPath := "~/documents/config.json"
+	expandedPath := ExpandHome(originalPath)
+	abbreviatedPath := AbbreviateHome(expandedPath)
+
+	if abbreviatedPath != originalPath {
+		t.Errorf("Round trip failed: %q -> %q -> %q", originalPath, expandedPath, abbreviatedPath)
+	}
+
+	// Test the other direction: abbreviate then expand
+	fullPath := filepath.Join(homeDir, "test", "file.txt")
+	abbreviated := AbbreviateHome(fullPath)
+	expanded := ExpandHome(abbreviated)
+
+	if expanded != fullPath {
+		t.Errorf("Reverse round trip failed: %q -> %q -> %q", fullPath, abbreviated, expanded)
+	}
+}
+
+func TestPromoteFileErrors(t *testing.T) {
+	// Create a host that might fail operations
+	localhost := host.Localhost
+
+	// Test with non-existent directory (should handle gracefully)
+	result := PromoteFile(localhost, "/nonexistent/path/file1", "/nonexistent/path/file2")
+	if result != "" {
+		t.Errorf("PromoteFile() with non-existent files should return empty string, got %q", result)
+	}
+}
+
+func TestFilePathEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		function string
+		input    string
+		expected func(string) bool // function to validate the result
+	}{
+		{
+			name:     "AbbreviateHome with trailing slash",
+			function: "AbbreviateHome",
+			input:    "/some/path/",
+			expected: func(result string) bool { return result == "/some/path/" },
+		},
+		{
+			name:     "ExpandHome with multiple tildes",
+			function: "ExpandHome",
+			input:    "~/~/test",
+			expected: func(result string) bool { 
+				homeDir, _ := os.UserHomeDir()
+				return strings.HasPrefix(result, homeDir)
+			},
+		},
+		{
+			name:     "ExpandHome with tilde not at start",
+			function: "ExpandHome", 
+			input:    "prefix~/test",
+			expected: func(result string) bool { return result == "prefix~/test" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result string
+			switch tt.function {
+			case "AbbreviateHome":
+				result = AbbreviateHome(tt.input)
+			case "ExpandHome":
+				result = ExpandHome(tt.input)
+			}
+
+			if !tt.expected(result) {
+				t.Errorf("%s(%q) = %q, validation failed", tt.function, tt.input, result)
+			}
+		})
+	}
+}
+
+func TestPromoteFileWithPermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	localhost := host.Localhost
+
+	// Create a test file with specific permissions
+	testFile := filepath.Join(tempDir, "perm_test.txt")
+	err := os.WriteFile(testFile, []byte("test"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	targetFile := filepath.Join(tempDir, "target.txt")
+
+	// Promote the file
+	result := PromoteFile(localhost, targetFile, testFile)
+
+	if result != targetFile {
+		t.Errorf("PromoteFile() = %q, want %q", result, targetFile)
+	}
+
+	// Verify the file exists at the target location
+	if _, err := os.Stat(result); os.IsNotExist(err) {
+		t.Error("Promoted file should exist at target location")
+	}
+}
+
+func TestExpandHomeBytesEdgeCases(t *testing.T) {
+	// Test with nil input
+	result := ExpandHomeBytes(nil)
+	if result != nil {
+		t.Errorf("ExpandHomeBytes(nil) = %v, want nil", result)
+	}
+
+	// Test with binary data that contains tilde-like sequences
+	binaryData := []byte{0x7e, 0x2f, 0x00, 0x01, 0x02} // starts with ~/
+	result = ExpandHomeBytes(binaryData)
+	// Should handle binary data gracefully (behavior may vary)
+	if result == nil {
+		t.Error("ExpandHomeBytes() should not return nil for valid input")
+	}
+}

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -1,0 +1,398 @@
+/*
+Copyright © 2022 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir := t.TempDir()
+
+	// Create test config files
+	jsonConfig := `{
+		"database": {
+			"host": "localhost",
+			"port": 5432
+		},
+		"app": {
+			"name": "testapp",
+			"debug": true
+		}
+	}`
+
+	yamlConfig := `
+database:
+  host: remotehost
+  port: 3306
+app:
+  name: yamlapp
+  timeout: 30
+`
+
+	jsonFile := filepath.Join(tempDir, "test.json")
+	yamlFile := filepath.Join(tempDir, "test.yaml")
+
+	err := os.WriteFile(jsonFile, []byte(jsonConfig), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test JSON file: %v", err)
+	}
+
+	err = os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test YAML file: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		configName  string
+		options     []FileOptions
+		wantErr     bool
+		wantHost    string
+		wantPort    int
+		wantAppName string
+	}{
+		{
+			name:        "load JSON config",
+			configName:  "test",
+			options:     []FileOptions{SetConfigFile(jsonFile)},
+			wantErr:     false,
+			wantHost:    "localhost",
+			wantPort:    5432,
+			wantAppName: "testapp",
+		},
+		{
+			name:        "load YAML config",
+			configName:  "test",
+			options:     []FileOptions{SetConfigFile(yamlFile)},
+			wantErr:     false,
+			wantHost:    "remotehost",
+			wantPort:    3306,
+			wantAppName: "yamlapp",
+		},
+		{
+			name:       "load from directory",
+			configName: "test",
+			options:    []FileOptions{AddDirs(tempDir)},
+			wantErr:    false,
+			// Should find the first config file (order depends on filesystem)
+		},
+		{
+			name:       "non-existent config",
+			configName: "nonexistent",
+			options:    []FileOptions{AddDirs(tempDir)},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := Load(tt.configName, tt.options...)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Load() expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+			
+			if config == nil {
+				t.Fatal("Load() returned nil config")
+			}
+
+			// Test loaded values (only for specific test cases)
+			if tt.wantHost != "" {
+				if got := config.GetString("database.host"); got != tt.wantHost {
+					t.Errorf("database.host = %q, want %q", got, tt.wantHost)
+				}
+			}
+			
+			if tt.wantPort != 0 {
+				if got := config.GetInt("database.port"); got != tt.wantPort {
+					t.Errorf("database.port = %d, want %d", got, tt.wantPort)
+				}
+			}
+			
+			if tt.wantAppName != "" {
+				if got := config.GetString("app.name"); got != tt.wantAppName {
+					t.Errorf("app.name = %q, want %q", got, tt.wantAppName)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadWithDefaults(t *testing.T) {
+	defaults := `{
+		"database": {
+			"host": "defaulthost",
+			"port": 5432,
+			"timeout": 30
+		},
+		"app": {
+			"name": "defaultapp"
+		}
+	}`
+
+	// Create a temporary config file with some values
+	tempDir := t.TempDir()
+	configContent := `{
+		"database": {
+			"host": "confighost"
+		},
+		"app": {
+			"debug": true
+		}
+	}`
+	
+	configFile := filepath.Join(tempDir, "test.json")
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config file: %v", err)
+	}
+
+	config, err := Load("test",
+		WithDefaults([]byte(defaults), "json"),
+		SetConfigFile(configFile),
+	)
+	
+	if err != nil {
+		t.Fatalf("Load() with defaults failed: %v", err)
+	}
+
+	// Should have values from both defaults and config file
+	if got := config.GetString("database.host"); got != "confighost" {
+		t.Errorf("database.host = %q, want 'confighost' (from config file)", got)
+	}
+	
+	if got := config.GetInt("database.port"); got != 5432 {
+		t.Errorf("database.port = %d, want 5432 (from defaults)", got)
+	}
+	
+	if got := config.GetInt("database.timeout"); got != 30 {
+		t.Errorf("database.timeout = %d, want 30 (from defaults)", got)
+	}
+	
+	if got := config.GetString("app.name"); got != "defaultapp" {
+		t.Errorf("app.name = %q, want 'defaultapp' (from defaults)", got)
+	}
+	
+	if got := config.GetBool("app.debug"); got != true {
+		t.Errorf("app.debug = %t, want true (from config file)", got)
+	}
+}
+
+func TestLoadMergeSettings(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create multiple config files
+	config1 := `{"key1": "value1", "shared": "from_config1"}`
+	config2 := `{"key2": "value2", "shared": "from_config2"}`
+
+	file1 := filepath.Join(tempDir, "config1.json")
+	file2 := filepath.Join(tempDir, "config2.json")
+
+	err := os.WriteFile(file1, []byte(config1), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create config1: %v", err)
+	}
+
+	err = os.WriteFile(file2, []byte(config2), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create config2: %v", err)
+	}
+
+	// Test without merge (should only load first file found)
+	config, err := Load("config1",
+		AddDirs(tempDir),
+	)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if config.GetString("key2") == "value2" {
+		t.Error("Without MergeSettings, should not load second config")
+	}
+
+	// Test with merge - note: actual merging behavior depends on implementation
+	// This is more of a smoke test to ensure the option doesn't break loading
+	config, err = Load("config1",
+		AddDirs(tempDir),
+		MergeSettings(),
+	)
+	if err != nil {
+		t.Fatalf("Load() with MergeSettings failed: %v", err)
+	}
+
+	if config == nil {
+		t.Fatal("Load() with MergeSettings returned nil")
+	}
+}
+
+func TestLoadSetGlobal(t *testing.T) {
+	tempDir := t.TempDir()
+	
+	configContent := `{"test": {"global": true}}`
+	configFile := filepath.Join(tempDir, "global.json")
+	
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	// Load with SetGlobal option
+	originalGlobal := GetConfig()
+	
+	config, err := Load("global",
+		SetConfigFile(configFile),
+		UseGlobal(),
+	)
+	
+	if err != nil {
+		t.Fatalf("Load() with UseGlobal failed: %v", err)
+	}
+
+	// The returned config should be the same as the global one
+	currentGlobal := GetConfig()
+	if config != currentGlobal {
+		t.Error("Load() with UseGlobal should return the global config")
+	}
+
+	// Global config should have the loaded values
+	if !GetConfig().GetBool("test.global") {
+		t.Error("Global config should have loaded values")
+	}
+
+	// Reset global config for other tests
+	global = originalGlobal
+}
+
+func TestPath(t *testing.T) {
+	tempDir := t.TempDir()
+	
+	configFile := filepath.Join(tempDir, "pathtest.yaml")
+	err := os.WriteFile(configFile, []byte("test: value"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		options  []FileOptions
+		contains string
+	}{
+		{
+			name:     "specific file path",
+			options:  []FileOptions{SetConfigFile(configFile)},
+			contains: "pathtest.yaml",
+		},
+		{
+			name:     "directory search",
+			options:  []FileOptions{AddDirs(tempDir)},
+			contains: tempDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := Path("pathtest", tt.options...)
+			
+			if path == "" {
+				t.Error("Path() returned empty string")
+			}
+			
+			if !strings.Contains(path, tt.contains) {
+				t.Errorf("Path() = %q, should contain %q", path, tt.contains)
+			}
+		})
+	}
+}
+
+func TestLoadWithReader(t *testing.T) {
+	configContent := `{
+		"reader": {
+			"test": true,
+			"value": 42
+		}
+	}`
+
+	config, err := Load("reader",
+		SetConfigReader(strings.NewReader(configContent)),
+		SetFileExtension("json"),
+	)
+
+	if err != nil {
+		t.Fatalf("Load() with reader failed: %v", err)
+	}
+
+	if !config.GetBool("reader.test") {
+		t.Error("Config from reader should have reader.test = true")
+	}
+
+	if config.GetInt("reader.value") != 42 {
+		t.Errorf("reader.value = %d, want 42", config.GetInt("reader.value"))
+	}
+}
+
+func TestLoadMustExist(t *testing.T) {
+	// Test that MustExist option causes error when file doesn't exist
+	_, err := Load("nonexistent",
+		AddDirs("/nonexistent/path"),
+		MustExist(),
+	)
+
+	if err == nil {
+		t.Error("Load() with MustExist should fail when config doesn't exist")
+	}
+}
+
+func TestLoadIgnoreOptions(t *testing.T) {
+	tempDir := t.TempDir()
+	
+	configContent := `{"ignore": {"test": true}}`
+	configFile := filepath.Join(tempDir, "ignore.json")
+	
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	// Test various ignore options don't break loading
+	config, err := Load("ignore",
+		SetConfigFile(configFile),
+		IgnoreWorkingDir(),
+		IgnoreUserConfDir(),
+		IgnoreSystemDir(),
+	)
+
+	if err != nil {
+		t.Fatalf("Load() with ignore options failed: %v", err)
+	}
+
+	if !config.GetBool("ignore.test") {
+		t.Error("Config should have loaded despite ignore options")
+	}
+}

--- a/pkg/config/save_test.go
+++ b/pkg/config/save_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright © 2023 ITRS Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/itrs-group/cordial/pkg/host"
+)
+
+func TestSave(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a config with some test data
+	config := New()
+	config.Set("app.name", "testapp")
+	config.Set("app.version", "1.0.0")
+	config.Set("database.host", "localhost")
+	config.Set("database.port", 5432)
+
+	tests := []struct {
+		name        string
+		configName  string
+		options     []FileOptions
+		wantErr     bool
+		wantFile    string
+		checkValues bool
+	}{
+		{
+			name:        "save to temp directory",
+			configName:  "test",
+			options:     []FileOptions{AddDirs(tempDir)},
+			wantErr:     false,
+			wantFile:    filepath.Join(tempDir, "test.json"),
+			checkValues: true,
+		},
+		{
+			name:        "save with custom extension",
+			configName:  "test-yaml",
+			options:     []FileOptions{AddDirs(tempDir), SetFileExtension("yaml")},
+			wantErr:     false,
+			wantFile:    filepath.Join(tempDir, "test-yaml.yaml"),
+			checkValues: false, // YAML parsing would require more setup
+		},
+		{
+			name:       "save to specific file",
+			configName: "specific",
+			options: []FileOptions{
+				SetConfigFile(filepath.Join(tempDir, "custom.json")),
+			},
+			wantErr:     false,
+			wantFile:    filepath.Join(tempDir, "custom.json"),
+			checkValues: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.Save(tt.configName, tt.options...)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Save() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Save() unexpected error: %v", err)
+			}
+
+			// Check that file was created
+			if _, err := os.Stat(tt.wantFile); os.IsNotExist(err) {
+				t.Errorf("Save() should have created file %s", tt.wantFile)
+			}
+
+			if tt.checkValues {
+				// Verify content by loading it back
+				savedConfig, err := Load(tt.configName, SetConfigFile(tt.wantFile))
+				if err != nil {
+					t.Fatalf("Failed to load saved config: %v", err)
+				}
+
+				if savedConfig.GetString("app.name") != "testapp" {
+					t.Error("Saved config should preserve app.name")
+				}
+
+				if savedConfig.GetString("database.host") != "localhost" {
+					t.Error("Saved config should preserve database.host")
+				}
+
+				if savedConfig.GetInt("database.port") != 5432 {
+					t.Error("Saved config should preserve database.port")
+				}
+			}
+		})
+	}
+}
+
+func TestSaveGlobal(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Set some values in global config
+	ResetConfig()
+	GetConfig().Set("global.test", "value")
+	GetConfig().Set("global.number", 123)
+
+	err := Save("global-test", AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("Save() global config failed: %v", err)
+	}
+
+	expectedFile := filepath.Join(tempDir, "global-test.json")
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		t.Errorf("Save() should have created file %s", expectedFile)
+	}
+
+	// Verify content
+	savedConfig, err := Load("global-test", SetConfigFile(expectedFile))
+	if err != nil {
+		t.Fatalf("Failed to load saved global config: %v", err)
+	}
+
+	if savedConfig.GetString("global.test") != "value" {
+		t.Error("Saved global config should preserve values")
+	}
+
+	if savedConfig.GetInt("global.number") != 123 {
+		t.Error("Saved global config should preserve numbers")
+	}
+}
+
+func TestSaveWithHost(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := New()
+	config.Set("host.test", "remote")
+
+	// Use localhost host for testing
+	localhost := host.Localhost
+
+	err := config.Save("host-test",
+		AddDirs(tempDir),
+		Host(localhost),
+	)
+
+	if err != nil {
+		t.Fatalf("Save() with host failed: %v", err)
+	}
+
+	expectedFile := filepath.Join(tempDir, "host-test.json")
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		t.Errorf("Save() with host should have created file %s", expectedFile)
+	}
+}
+
+func TestSaveErrors(t *testing.T) {
+	config := New()
+	config.Set("test", "value")
+
+	// Test saving to non-existent directory without create permissions
+	err := config.Save("error-test",
+		SetConfigFile("/root/cannot-create/test.json"),
+	)
+
+	if err == nil {
+		t.Error("Save() should fail when unable to create file")
+	}
+}
+
+func TestSaveAppConfig(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := New(SetAppName("testapp"))
+	config.Set("app.config", "test")
+
+	// This should save to a subdirectory based on app name
+	err := config.Save("app-config",
+		AddDirs(tempDir),
+	)
+
+	if err != nil {
+		t.Fatalf("Save() app config failed: %v", err)
+	}
+
+	// File should be created in app-specific directory
+	expectedDir := filepath.Join(tempDir, "testapp")
+	expectedFile := filepath.Join(expectedDir, "app-config.json")
+
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		// If app-specific directory doesn't exist, file might be in root
+		altFile := filepath.Join(tempDir, "app-config.json")
+		if _, err := os.Stat(altFile); os.IsNotExist(err) {
+			t.Errorf("Save() should have created file in %s or %s", expectedFile, altFile)
+		}
+	}
+}
+
+func TestSaveFileExtensions(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := New()
+	config.Set("ext.test", "value")
+
+	extensions := []string{"json", "yaml", "yml", "toml"}
+
+	for _, ext := range extensions {
+		t.Run("extension_"+ext, func(t *testing.T) {
+			err := config.Save("ext-test",
+				AddDirs(tempDir),
+				SetFileExtension(ext),
+			)
+
+			if err != nil {
+				t.Fatalf("Save() with extension %s failed: %v", ext, err)
+			}
+
+			expectedFile := filepath.Join(tempDir, "ext-test."+ext)
+			if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+				t.Errorf("Save() should have created file %s", expectedFile)
+			}
+		})
+	}
+}
+
+func TestSavePreservesType(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a config with a known type
+	jsonConfig := New()
+	jsonConfig.Type = "json"
+	jsonConfig.Set("type.test", "json")
+
+	err := jsonConfig.Save("type-test", AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	// Load it back and check type is preserved
+	loadedConfig, err := Load("type-test", AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if loadedConfig.Type != "json" {
+		t.Errorf("Config type = %q, want 'json'", loadedConfig.Type)
+	}
+}
+
+func TestSaveOverwrite(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "overwrite.json")
+
+	// Create initial config
+	config1 := New()
+	config1.Set("version", 1)
+	config1.Set("data", "original")
+
+	err := config1.Save("overwrite", SetConfigFile(configFile))
+	if err != nil {
+		t.Fatalf("First save failed: %v", err)
+	}
+
+	// Modify and save again
+	config2 := New()
+	config2.Set("version", 2)
+	config2.Set("data", "updated")
+
+	err = config2.Save("overwrite", SetConfigFile(configFile))
+	if err != nil {
+		t.Fatalf("Second save failed: %v", err)
+	}
+
+	// Verify the file was overwritten
+	finalConfig, err := Load("overwrite", SetConfigFile(configFile))
+	if err != nil {
+		t.Fatalf("Load after overwrite failed: %v", err)
+	}
+
+	if finalConfig.GetInt("version") != 2 {
+		t.Errorf("version = %d, want 2", finalConfig.GetInt("version"))
+	}
+
+	if finalConfig.GetString("data") != "updated" {
+		t.Errorf("data = %q, want 'updated'", finalConfig.GetString("data"))
+	}
+}
+
+func TestSaveComplexData(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := New()
+
+	// Set complex nested data
+	config.Set("database.connections.primary.host", "db1.example.com")
+	config.Set("database.connections.primary.port", 5432)
+	config.Set("database.connections.secondary.host", "db2.example.com")
+	config.Set("database.connections.secondary.port", 5433)
+
+	// Set arrays
+	config.Set("servers", []string{"web1", "web2", "web3"})
+	config.Set("ports", []int{8080, 8081, 8082})
+
+	// Set maps
+	envVars := map[string]string{
+		"NODE_ENV": "production",
+		"LOG_LEVEL": "info",
+	}
+	config.Set("environment", envVars)
+
+	err := config.Save("complex", AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("Save() complex data failed: %v", err)
+	}
+
+	// Verify by loading back
+	loadedConfig, err := Load("complex", AddDirs(tempDir))
+	if err != nil {
+		t.Fatalf("Load() complex data failed: %v", err)
+	}
+
+	// Check nested values
+	if loadedConfig.GetString("database.connections.primary.host") != "db1.example.com" {
+		t.Error("Complex nested string not preserved")
+	}
+
+	if loadedConfig.GetInt("database.connections.secondary.port") != 5433 {
+		t.Error("Complex nested int not preserved")
+	}
+
+	// Check arrays
+	servers := loadedConfig.GetStringSlice("servers")
+	if len(servers) != 3 || servers[0] != "web1" {
+		t.Error("String slice not preserved")
+	}
+
+	// Check environment map
+	if loadedConfig.GetString("environment.NODE_ENV") != "production" {
+		t.Error("Map values not preserved")
+	}
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds a comprehensive test suite for the `pkg/config` package.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces a new, comprehensive test suite for the `pkg/config` package, covering core configuration, loading, saving, variable expansion, encryption, credential management, file utilities, and file options. This significantly improves code quality, ensures correctness, and provides a robust foundation for future development and refactoring.

---
<a href="https://cursor.com/background-agent?bcId=bc-5da6fb0a-98b3-4ca1-b8db-6f129d85e523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5da6fb0a-98b3-4ca1-b8db-6f129d85e523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>