### PR TITLE
tools/dv2email - Add command-line flag (-s/--subject) for email subject

### DIFF
--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -195,7 +195,7 @@ func splitCommaTrimSpace(s string) []string {
 }
 
 // NewEmailConfig sets up a config.Config containing Geneos specific email settings, ready to use with
-func NewEmailConfig(cf *config.Config, toArg, ccArg, bccArg string) (em *config.Config) {
+func NewEmailConfig(cf *config.Config, toArg, ccArg, bccArg, subjectArg string) (em *config.Config) {
 	em = config.New()
 	// set default from yaml file, can be overridden from Geneos as
 	// environment variables
@@ -251,6 +251,9 @@ func NewEmailConfig(cf *config.Config, toArg, ccArg, bccArg string) (em *config.
 	}
 	if bccArg != "" {
 		em.Set("_bcc", bccArg)
+	}
+	if subjectArg != "" {
+		em.Set("_subject", subjectArg)
 	}
 
 	return

--- a/tools/dv2email/cmd/root.go
+++ b/tools/dv2email/cmd/root.go
@@ -40,7 +40,7 @@ var debug, quiet bool
 var inlineCSS bool
 
 var entityArg, samplerArg, typeArg, dataviewArg string
-var toArg, ccArg, bccArg string
+var toArg, ccArg, bccArg, subjectArg string
 
 func init() {
 	// cobra.OnInitialize(initConfig)
@@ -63,6 +63,7 @@ func init() {
 	DV2EMAILCmd.Flags().StringVarP(&toArg, "to", "t", "", "To as comma-separated emails")
 	DV2EMAILCmd.Flags().StringVarP(&ccArg, "cc", "c", "", "Cc as comma-separated emails")
 	DV2EMAILCmd.Flags().StringVarP(&bccArg, "bcc", "b", "", "Bcc as comma-separated emails")
+	DV2EMAILCmd.Flags().StringVarP(&subjectArg, "subject", "s", "", "Subject of the email")
 
 	DV2EMAILCmd.Flags().SortFlags = false
 }
@@ -93,6 +94,7 @@ func initConfig() {
 		config.MergeSettings(),
 		config.SetFileExtension("yaml"),
 		config.WithDefaults(defaults, "yaml"),
+		config.WithEnvs("DV2EMAIL", "_"),
 	}
 
 	cf, err = config.Load(execname, opts...)
@@ -142,7 +144,7 @@ var DV2EMAILCmd = &cobra.Command{
 		}
 
 		// we need to pass filters etc. to fetchDataviews
-		em := email.NewEmailConfig(cf, toArg, ccArg, bccArg)
+		em := email.NewEmailConfig(cf, toArg, ccArg, bccArg, subjectArg)
 
 		data, err := fetchDataviews(cmd, gw,
 			em.GetString("_firstcolumn"),


### PR DESCRIPTION
Fixes #223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c7079e88c7355ac3c2bfb6632d8ecbc643f2fa3b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->